### PR TITLE
catalogues: passed Catalogue in parameters

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
@@ -62,21 +62,20 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
         return updatedCatalogue
     }
 
-    override fun changeParentCatalogue(catalogueId: String, parentCatalogueId: String): Pair<Catalogue, Catalogue> {
+    override fun changeParentCatalogue(catalogueId: String, parentCatalogue: Catalogue): Catalogue {
         val childCatalogue = findOrThrow(catalogueId)
 
-        if(childCatalogue.parentCatalogue == parentCatalogueId) throw CatalogueAlreadyAChildException()
+        if(childCatalogue.parentCatalogue == parentCatalogue.id) throw CatalogueAlreadyAChildException()
+        if(childCatalogue.id == parentCatalogue.id) throw SelfContainedCatalogueException()
 
-        val parentCatalogue = findOrThrow(parentCatalogueId)
-
-        val updatedChild = childCatalogue.copy(parentCatalogue = parentCatalogueId)
+        val updatedChild = childCatalogue.copy(parentCatalogue = parentCatalogue.id)
         val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues
                 .append(catalogueId))
 
         coll.update(updatedChild)
         coll.update(updatedParent)
 
-        return (updatedParent to updatedChild)
+        return updatedChild
     }
 
     override fun delete(catalogueId: String): Catalogue {
@@ -87,17 +86,15 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
         return catalogue
     }
 
-    override fun appendSubCatalogue(parentCatalogueId: String, subCatalogueId: String): Catalogue {
-        val childCatalogue = findOrThrow(subCatalogueId)
+    override fun appendSubCatalogue(catalogueId: String, subCatalogue: Catalogue): Catalogue {
+        if(subCatalogue.parentCatalogue == catalogueId) throw CatalogueAlreadyAChildException()
 
-        if(childCatalogue.parentCatalogue == parentCatalogueId) throw CatalogueAlreadyAChildException()
+        if(subCatalogue.id == catalogueId) throw SelfContainedCatalogueException()
 
-        if(childCatalogue.id == parentCatalogueId) throw SelfContainedCatalogueException()
+        val parentCatalogue = findOrThrow(catalogueId)
 
-        val parentCatalogue = findOrThrow(parentCatalogueId)
-
-        val updatedChild = childCatalogue.copy(parentCatalogue = parentCatalogueId)
-        val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues.append(subCatalogueId))
+        val updatedChild = subCatalogue.copy(parentCatalogue = catalogueId)
+        val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues.append(subCatalogue.id))
 
         coll.update(updatedChild)
         coll.update(updatedParent)
@@ -105,16 +102,14 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
         return updatedChild
     }
 
-    override fun removeSubCatalogue(parentCatalogueId: String, subCatalogueId: String): Catalogue {
-        val childCatalogue = findOrThrow(subCatalogueId)
+    override fun removeSubCatalogue(catalogueId: String, subCatalogue: Catalogue): Catalogue {
+        if(subCatalogue.parentCatalogue != catalogueId) throw CatalogueNotAChildException()
 
-        if(childCatalogue.parentCatalogue != parentCatalogueId) throw CatalogueNotAChildException()
+        val parentCatalogue = findOrThrow(catalogueId)
 
-        val parentCatalogue = findOrThrow(parentCatalogueId)
+        val updatedChild = subCatalogue.copy(parentCatalogue = "None")
 
-        val updatedChild = childCatalogue.copy(parentCatalogue = "None")
-
-        val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues.subtract(subCatalogueId))
+        val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues.subtract(subCatalogue.id))
 
         coll.update(updatedChild)
         coll.update(updatedParent)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
@@ -45,12 +45,12 @@ interface Catalogues {
      * Changes the parent of a catalogue.
      *
      * @param catalogueId The id of the catalogue targeted.
-     * @param parentCatalogueId The id of the new parent.
-     * @return The new parent catalogue and the updated child catalogue.
+     * @param parentCatalogue The id of the new parent.
+     * @return The updated child catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
             CatalogueAlreadyAChildException::class)
-    fun changeParentCatalogue(catalogueId: String, parentCatalogueId: String): Pair<Catalogue, Catalogue>
+    fun changeParentCatalogue(catalogueId: String, parentCatalogue: Catalogue): Catalogue
 
     /**
      * Deletes a catalogue by id.
@@ -64,25 +64,25 @@ interface Catalogues {
     /**
      * Appends a catalogue to the targeted catalogue's children list.
      *
-     * @param parentCatalogueId The id of the parent catalogue.
-     * @param subCatalogueId The id of the child catalogue.
-     * @return The appended catalogue.
+     * @param catalogueId The id of the targeted parent catalogue.
+     * @param subCatalogue The id of the child catalogue.
+     * @return The updated parent catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
             CatalogueAlreadyAChildException::class,
             SelfContainedCatalogueException::class)
-    fun appendSubCatalogue(parentCatalogueId: String, subCatalogueId: String): Catalogue
+    fun appendSubCatalogue(catalogueId: String, subCatalogue: Catalogue): Catalogue
 
     /**
      * Removes a catalogue from the targeted catalogue's children list.
      *
-     * @param parentCatalogueId The id of the parent catalogue.
-     * @param subCatalogueId The id of the child catalogue.
-     * @return The removed catalogue.
+     * @param catalogueId The id of the parent catalogue.
+     * @param subCatalogue The id of the child catalogue.
+     * @return The updated parent catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
             CatalogueNotAChildException::class)
-    fun removeSubCatalogue(parentCatalogueId: String, subCatalogueId: String): Catalogue
+    fun removeSubCatalogue(catalogueId: String, subCatalogue: Catalogue): Catalogue
 
     /**
      * Appends an article from a catalogue.


### PR DESCRIPTION
Changed catalogue interface so that when a second catalogue is required it is passed as an object. Closes #21.