### PR TITLE
nharker-core: added trash store

### DIFF
--- a/nharker-core/build.gradle
+++ b/nharker-core/build.gradle
@@ -9,7 +9,13 @@ repositories {
 dependencies {
     compile 'org.slf4j:slf4j-simple:1.7.25'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    //Nitrite
     compile "org.dizitart:potassium-nitrite:$nitriteVersion"
+
+    //Jackson
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.6'
+    compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.4.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
@@ -1,0 +1,49 @@
+package com.tsbonev.nharker.adapter.nitrite
+
+import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.helpers.toDocument
+import com.tsbonev.nharker.core.helpers.toEntity
+import org.dizitart.kno2.filters.eq
+import org.dizitart.no2.Nitrite
+import org.dizitart.no2.NitriteCollection
+
+/**
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+class NitriteEntityTrashCollector(private val nitriteDb: Nitrite,
+                                  private val collectionName: String = "Entity_trash") : TrashCollector {
+    /**
+     * Retrieve the repository on every request.
+     */
+    private val coll: NitriteCollection
+        get() = nitriteDb.getCollection(collectionName)
+
+    override fun view(): List<Entity> {
+        val docList = coll.find().toList()
+
+        val entityList = mutableListOf<Entity>()
+
+        docList.forEach { entityList.add(it.toEntity()) }
+
+        return entityList
+    }
+
+    override fun trash(entity: Entity) {
+        if (coll.find("entityId" eq entity.id).firstOrNull() != null)
+            throw EntityAlreadyInTrashException()
+
+        coll.insert(entity.toDocument())
+    }
+
+    override fun restore(id: String): Entity {
+        val restoredDoc = coll.find("entityId" eq id).firstOrNull()
+                ?: throw EntityNotInTrashException()
+
+        coll.remove(restoredDoc)
+        return restoredDoc.toEntity()
+    }
+
+    override fun clear() {
+        coll.drop()
+    }
+}

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
@@ -19,14 +19,14 @@ import java.time.LocalDateTime
 @Indices(Index(value = "linkTitle", type = IndexType.NonUnique),
         Index(value = "fullTitle", type = IndexType.Fulltext),
         Index(value = "catalogueId", type = IndexType.NonUnique))
-data class Article(@Id val id: String,
+data class Article(@Id override val id: String,
                    val linkTitle: String,
                    val fullTitle: String,
                    val creationDate: LocalDateTime,
                    val catalogueId: String = ReferenceId.None.value,
                    val properties: List<ArticleProperty> = emptyList(),
                    val entries: Map<String, Int> = emptyMap(),
-                   val links: ArticleLinks = ArticleLinks(mutableMapOf()))
+                   val links: ArticleLinks = ArticleLinks(mutableMapOf())) : Entity(id)
 
 /**
  * Converts a full text title to a lowercase, dash-concatenated string.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
@@ -17,12 +17,12 @@ import java.time.LocalDateTime
  */
 @Indices(Index(value = "parentCatalogue", type = IndexType.NonUnique),
         Index(value = "title", type = IndexType.Unique))
-data class Catalogue(@Id val id: String,
+data class Catalogue(@Id override val id: String,
                      val title: String,
                      val creationDate: LocalDateTime,
                      val articles: Map<String, Int> = emptyMap(),
                      val subCatalogues: Map<String, Int> = emptyMap(),
-                     val parentCatalogue: String = ReferenceId.None.value)
+                     val parentCatalogue: String = ReferenceId.None.value) : Entity(id)
 
 class CatalogueNotFoundException : Exception()
 class CatalogueAlreadyAChildException : Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
@@ -1,0 +1,10 @@
+package com.tsbonev.nharker.core
+
+/**
+ * Entity is the base of all domain object, it enforces all of them
+ * to have an id and allows for less duplication when working with
+ * generic collections.
+ *
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+open class Entity(open val id: String)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
@@ -15,11 +15,11 @@ import java.time.LocalDateTime
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 @Indices(Index(value = "content", type = IndexType.Fulltext))
-data class Entry (@Id val id: String,
+data class Entry (@Id override val id: String,
                   val creationDate: LocalDateTime,
                   val articleId: String = ReferenceId.None.value,
                   val content: String,
-                  val links: Map<String, String>)
+                  val links: Map<String, String> = emptyMap()) : Entity(id)
 
 class EntryAlreadyInArticleException : Exception()
 class EntryNotFoundException : Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/TrashCollector.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/TrashCollector.kt
@@ -1,0 +1,43 @@
+package com.tsbonev.nharker.core
+
+import java.lang.Exception
+
+/**
+ * Provides the methods to store a deleted entity in a
+ * collection and be retrieved on a later basis.
+ *
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+interface TrashCollector {
+    /**
+     * Returns a list of trashed entities.
+     *
+     * @return The list of trashed entities.
+     */
+    fun view(): List<Entity>
+
+    /**
+     * Stores an entity into the trash collection.
+     *
+     * @param entity Entity to trash.
+     */
+    @Throws(EntityAlreadyInTrashException::class)
+    fun trash(entity: Entity)
+
+    /**
+     * Retrieves an entity from the trash.
+     *
+     * @param id The id of the entity.
+     * @return The restored entity.
+     */
+    @Throws(EntityNotInTrashException::class)
+    fun restore(id: String): Entity
+
+    /**
+     * Clears all trashed entities.
+     */
+    fun clear()
+}
+
+class EntityAlreadyInTrashException: Exception()
+class EntityNotInTrashException: Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
@@ -1,0 +1,40 @@
+package com.tsbonev.nharker.core.helpers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.tsbonev.nharker.core.Entity
+import org.dizitart.no2.Document
+
+/**
+ * Converters used by the trash store utilizing Jackson.
+ *
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+
+/**
+ * Converts any Entity to a document with three fields,
+ * a class, an id and a json body.
+ */
+fun Entity.toDocument(): Document {
+    val document = Document()
+    document["entityId"] = this.id
+    document["json"] = ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .writeValueAsString(this)
+    document["class"] = this::class.java.name
+    return document
+}
+
+/**
+ * Converts any document with a class and json field to
+ * that class and the casts it as an Entity.
+ */
+fun Document.toEntity(): Entity {
+    return ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .readValue(this["json"].toString(),
+            Class.forName(this["class"].toString())) as Entity
+}

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
@@ -1,0 +1,115 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package com.tsbonev.nharker.adapter.nitrite
+
+import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.helpers.toDocument
+import com.tsbonev.nharker.core.helpers.toEntity
+import org.dizitart.kno2.filters.eq
+import org.dizitart.kno2.nitrite
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import org.hamcrest.CoreMatchers.`is` as Is
+import org.junit.Assert.assertThat
+import org.junit.Before
+
+/**
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+class NitriteEntityTrashCollectorTest {
+
+    private val db = nitrite { }
+
+    private val date = LocalDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneOffset.UTC)
+
+    private val entry = Entry(
+            "::entryId::",
+            date,
+            content = "::content::"
+    )
+
+    private val trashedEntry = Entry(
+            "::trashedEntryId::",
+            date,
+            content = "::content::"
+    )
+
+    private val article = Article(
+            "::articleId::",
+            "article-id",
+            "Article id",
+            date
+    )
+
+    private val entryTrashCollectionName = "Test_entries_trash"
+
+    private val trashCollector = NitriteEntityTrashCollector(db, entryTrashCollectionName)
+
+    private val coll = db.getCollection(entryTrashCollectionName)
+    
+    @Before
+    fun setUp(){
+        coll.insert(trashedEntry.toDocument())
+    }
+    
+    @Test
+    fun `Trash entity`(){
+        trashCollector.trash(entry)
+
+        assertThat(findEntity(entry.id) as Entry, Is(entry))
+    }
+
+    @Test
+    fun `Trash entities of differing types`(){
+        trashCollector.trash(entry)
+        trashCollector.trash(article)
+
+        assertThat(findEntity(article.id) as Article, Is(article))
+        assertThat(findEntity(entry.id) as Entry, Is(entry))
+    }
+
+    @Test(expected = EntityAlreadyInTrashException::class)
+    fun `Trashing same entity twice throws exception`(){
+        trashCollector.trash(trashedEntry)
+    }
+
+    @Test
+    fun `Restore entity from trash`(){
+        val restoredEntry = trashCollector.restore(trashedEntry.id) as Entry
+
+        assertThat(restoredEntry, Is(trashedEntry))
+    }
+
+    @Test
+    fun `Restoring entity removes it from trash`(){
+        trashCollector.restore(trashedEntry.id)
+
+        assertThat(coll.find("entityId" eq entry.id).firstOrNull(), Is(nullValue()))
+    }
+
+    @Test(expected = EntityNotInTrashException::class)
+    fun `Restoring non-trashed entity throws exception`(){
+        trashCollector.restore(entry.id)
+    }
+
+    @Test
+    fun `View trashed entities`(){
+        val trashed = trashCollector.view() as List<Entry>
+
+        assertThat(trashed, Is(listOf(trashedEntry)))
+    }
+
+    @Test
+    fun `Clear trashed`(){
+        trashCollector.clear()
+
+        assertThat(coll.find().toList(), Is(emptyList()))
+    }
+
+    private fun findEntity(id: String): Entity {
+        return coll.find("entityId" eq id).first().toEntity()
+    }
+}


### PR DESCRIPTION
Added a nitrite document-based trash store that utilizes Jackson to convert any Entity back and forth, making for a single class that can store any domain object with an id. Closes #29 