### PR TITLE
nharker-core: remove unnecessary references in entities

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...90"
+
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 10
+        base: auto
+    patch:
+      default:
+          enabled: no
+          if_not_found: success
+    changes:
+      default:
+        enabled: no
+        if_not_found: success
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -29,8 +29,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
                 NitriteId.newId().toString(),
                 articleRequest.title.toLinkTitle(),
                 articleRequest.title,
-                LocalDateTime.now(clock),
-                articleRequest.catalogue
+                LocalDateTime.now(clock)
         )
 
         if(coll.find(Article::linkTitle eq article.linkTitle).firstOrNull() != null)
@@ -60,7 +59,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
 
         coll.update(updatedArticle)
 
-        return entry.copy(articleId = articleId)
+        return entry
     }
 
     override fun removeEntry(articleId: String, entry: Entry): Entry {
@@ -71,19 +70,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
         val updatedArticle = article.copy(entries = article.entries.subtract(entry.id))
         coll.update(updatedArticle)
 
-        return entry.copy(articleId = ReferenceId.Deleted.value)
-    }
-
-    override fun setCatalogue(articleId: String, catalogue: Catalogue): Catalogue {
-        val article = findByIdOrThrow(articleId)
-
-        if(article.catalogueId == catalogue.id) throw ArticleAlreadyInCatalogueException()
-
-        val updatedArticle = article.copy(catalogueId = catalogue.id)
-
-        coll.update(updatedArticle)
-
-        return catalogue.copy(articles = catalogue.articles.append(articleId))
+        return entry
     }
 
     override fun switchEntries(articleId: String, first: Entry, second: Entry): Article {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
@@ -103,7 +103,7 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
 
         val parentCatalogue = findOrThrow(catalogueId)
 
-        val updatedChild = subCatalogue.copy(parentCatalogue = ReferenceId.None.value)
+        val updatedChild = subCatalogue.copy(parentCatalogue = null)
 
         val updatedParent = parentCatalogue.copy(subCatalogues = parentCatalogue.subCatalogues.subtract(subCatalogue.id))
 
@@ -114,27 +114,27 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
     }
 
     override fun appendArticle(catalogueId: String, article: Article): Article {
-        if(article.catalogueId == catalogueId) throw ArticleAlreadyInCatalogueException()
-
         val catalogue = findOrThrow(catalogueId)
+
+        if(catalogue.articles.containsKey(article.id)) throw ArticleAlreadyInCatalogueException()
 
         val updatedCatalogue = catalogue.copy(articles = catalogue.articles.append(article.id))
 
         coll.update(updatedCatalogue)
 
-        return article.copy(catalogueId = catalogueId)
+        return article
     }
 
     override fun removeArticle(catalogueId: String, article: Article): Article {
-        if(article.catalogueId != catalogueId) throw ArticleNotInCatalogueException()
-
         val catalogue = findOrThrow(catalogueId)
+
+        if(!catalogue.articles.containsKey(article.id)) throw ArticleNotInCatalogueException()
 
         val updatedCatalogue = catalogue.copy(articles = catalogue.articles.subtract(article.id))
 
         coll.update(updatedCatalogue)
 
-        return article.copy(catalogueId = ReferenceId.None.value)
+        return article
     }
 
     override fun switchArticles(catalogueId: String, first: Article, second: Article): Catalogue {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
@@ -27,7 +27,6 @@ class NitriteEntries(private val nitriteDb: Nitrite,
         val entry = Entry(
                 NitriteId.newId().toString(),
                 LocalDateTime.now(clock),
-                entryRequest.articleId,
                 entryRequest.content,
                 entryRequest.links
         )
@@ -62,15 +61,6 @@ class NitriteEntries(private val nitriteDb: Nitrite,
         val entry = findByIdOrThrow(entryId)
         val updatedEntry = entry.copy(links = links)
 
-        coll.update(updatedEntry)
-        return updatedEntry
-    }
-
-    override fun changeArticle(entryId: String, articleId: String): Entry {
-        val entry = findByIdOrThrow(entryId)
-        if(entry.articleId == articleId) throw EntryAlreadyInArticleException()
-
-        val updatedEntry = entry.copy(articleId = articleId)
         coll.update(updatedEntry)
         return updatedEntry
     }

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
@@ -1,6 +1,5 @@
 package com.tsbonev.nharker.core
 
-import com.tsbonev.nharker.core.helpers.ReferenceId
 import org.dizitart.no2.IndexType
 import org.dizitart.no2.objects.Id
 import org.dizitart.no2.objects.Index
@@ -17,13 +16,11 @@ import java.time.LocalDateTime
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 @Indices(Index(value = "linkTitle", type = IndexType.NonUnique),
-        Index(value = "fullTitle", type = IndexType.Fulltext),
-        Index(value = "catalogueId", type = IndexType.NonUnique))
+        Index(value = "fullTitle", type = IndexType.Fulltext))
 data class Article(@Id val id: String,
                    val linkTitle: String,
                    val fullTitle: String,
                    val creationDate: LocalDateTime,
-                   val catalogueId: String = ReferenceId.None.value,
                    val properties: List<ArticleProperty> = emptyList(),
                    val entries: Map<String, Int> = emptyMap(),
                    val links: ArticleLinks = ArticleLinks(mutableMapOf()))
@@ -55,6 +52,7 @@ data class ArticleHead(val id: String,
                        val creationDate: LocalDateTime)
 
 class ArticleNotFoundException : Exception()
-class ArticleAlreadyInCatalogueException : Exception()
-class ArticleNotInCatalogueException : Exception()
 class ArticleTitleTakenException : Exception()
+
+class EntryAlreadyInArticleException : Exception()
+class EntryNotInArticleException : Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleRequest.kt
@@ -3,5 +3,4 @@ package com.tsbonev.nharker.core
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-data class ArticleRequest (val title: String,
-                           val catalogue: String)
+data class ArticleRequest (val title: String)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -53,17 +53,6 @@ interface Articles {
     fun removeEntry(articleId: String, entry: Entry): Entry
 
     /**
-     * Sets the catalogue of an article.
-     *
-     * @param articleId The value of the article targeted.
-     * @param catalogue The catalogue.
-     * @return The updated catalogue.
-     */
-    @Throws(ArticleNotFoundException::class,
-            ArticleAlreadyInCatalogueException::class)
-    fun setCatalogue(articleId: String, catalogue: Catalogue): Catalogue
-
-    /**
      * Switches two entries in the article.
      *
      * @param articleId The value of the article.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
@@ -1,6 +1,5 @@
 package com.tsbonev.nharker.core
 
-import com.tsbonev.nharker.core.helpers.ReferenceId
 import org.dizitart.no2.IndexType
 import org.dizitart.no2.objects.Id
 import org.dizitart.no2.objects.Index
@@ -22,10 +21,18 @@ data class Catalogue(@Id val id: String,
                      val creationDate: LocalDateTime,
                      val articles: Map<String, Int> = emptyMap(),
                      val subCatalogues: Map<String, Int> = emptyMap(),
-                     val parentCatalogue: String = ReferenceId.None.value)
+                     val parentCatalogue: String? = null){
+    fun hasParent(): Boolean {
+        return this.parentCatalogue != null
+    }
+}
 
 class CatalogueNotFoundException : Exception()
+class CatalogueTitleTakenException : Exception()
+
 class CatalogueAlreadyAChildException : Exception()
 class CatalogueNotAChildException : Exception()
-class CatalogueTitleTakenException : Exception()
 class SelfContainedCatalogueException : Exception()
+
+class ArticleAlreadyInCatalogueException : Exception()
+class ArticleNotInCatalogueException : Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
@@ -1,8 +1,6 @@
 package com.tsbonev.nharker.core
 
-import com.tsbonev.nharker.core.helpers.ReferenceId
-
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-data class CatalogueRequest(val title: String, val parentCatalogue: String = ReferenceId.None.value)
+data class CatalogueRequest(val title: String, val parentCatalogue: String? = null)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
@@ -65,15 +65,4 @@ interface Entries {
      * @return A list of matching entries.
      */
     fun getByContent(searchText: String): List<Entry>
-
-    /**
-     * Changes the article of an entry.
-     *
-     * @param entryId The value of the entry targeted.
-     * @param articleId The value of the new article.
-     * @return The updated entry.
-     */
-    @Throws(EntryNotFoundException::class,
-            EntryAlreadyInArticleException::class)
-    fun changeArticle(entryId: String, articleId: String): Entry
 }

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
@@ -1,6 +1,5 @@
 package com.tsbonev.nharker.core
 
-import com.tsbonev.nharker.core.helpers.ReferenceId
 import org.dizitart.no2.IndexType
 import org.dizitart.no2.objects.Id
 import org.dizitart.no2.objects.Index
@@ -17,10 +16,7 @@ import java.time.LocalDateTime
 @Indices(Index(value = "content", type = IndexType.Fulltext))
 data class Entry (@Id val id: String,
                   val creationDate: LocalDateTime,
-                  val articleId: String = ReferenceId.None.value,
                   val content: String,
                   val links: Map<String, String> = emptyMap())
 
-class EntryAlreadyInArticleException : Exception()
 class EntryNotFoundException : Exception()
-class EntryNotInArticleException : Exception()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryRequest.kt
@@ -4,5 +4,4 @@ package com.tsbonev.nharker.core
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class EntryRequest(val content: String,
-                        val articleId: String,
                         val links: Map<String, String>)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/ReferenceId.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/ReferenceId.kt
@@ -1,9 +1,0 @@
-package com.tsbonev.nharker.core.helpers
-
-/**
- * @author Tsvetozar Bonev (tsbonev@gmail.com)
- */
-enum class ReferenceId(val value: String) {
-    None("none"),
-    Deleted("deleted")
-}

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
@@ -1,9 +1,7 @@
 package com.tsbonev.nharker.adapter.nitrite
 
 import com.tsbonev.nharker.core.*
-import com.tsbonev.nharker.core.helpers.ReferenceId
 import com.tsbonev.nharker.core.helpers.StubClock
-import com.tsbonev.nharker.core.helpers.append
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.nitrite
 import org.junit.Before
@@ -25,16 +23,9 @@ class NitriteArticlesTest {
     private val stubClock = StubClock()
     private val collectionName = "TestArticles"
 
-    private val catalogue = Catalogue(
-            "::catalogueId::",
-            "::title::",
-            date
-    )
-
     private val entry = Entry(
             "::entryId::",
             date,
-            "::articleId::",
             "::content::",
             mapOf("::content::" to "::article::")
     )
@@ -42,7 +33,6 @@ class NitriteArticlesTest {
     private val firstPresavedEntry = Entry(
             "::firstPresavedEntryId::",
             date,
-            "::articleId::",
             "::content::",
             emptyMap()
     )
@@ -50,15 +40,13 @@ class NitriteArticlesTest {
     private val secondPresavedEntry = Entry(
             "::secondPresavedEntryId::",
             date,
-            "::articleId::",
             "::content::",
             emptyMap()
     )
 
 
     private val articleRequest = ArticleRequest(
-            "Article title",
-            "::default-catalogue::"
+            "Article title"
     )
 
     private val article = Article(
@@ -66,17 +54,10 @@ class NitriteArticlesTest {
             "article-title",
             "Article title",
             date,
-            "::default-catalogue::",
             emptyList(),
             mapOf(firstPresavedEntry.id to 0,
                     secondPresavedEntry.id to 1),
             ArticleLinks(mutableMapOf())
-    )
-
-    private val defaultCatalogue = Catalogue(
-            "::default-catalogue::",
-            "Default catalogue",
-            date
     )
 
     private val articles = NitriteArticles(db, collectionName, clock = stubClock)
@@ -133,7 +114,7 @@ class NitriteArticlesTest {
     fun `Remove and return entry from article`(){
         val removedEntry = articles.removeEntry(article.id, secondPresavedEntry)
 
-        assertThat(removedEntry, Is(secondPresavedEntry.copy(articleId = ReferenceId.Deleted.value)))
+        assertThat(removedEntry, Is(secondPresavedEntry))
         assertThat(presavedArticle().entries.count(), Is(1))
     }
 
@@ -153,24 +134,6 @@ class NitriteArticlesTest {
     @Test(expected = EntryNotInArticleException::class)
     fun `Deleting an entry that isn't in an article throws exception`(){
         articles.removeEntry(article.id, entry)
-    }
-
-    @Test
-    fun `Change article catalogue`(){
-        val changedCatalogue = articles.setCatalogue(article.id, catalogue)
-
-        assertThat(presavedArticle(), Is(article.copy(catalogueId = catalogue.id)))
-        assertThat(changedCatalogue, Is(catalogue.copy(articles= catalogue.articles.append(article.id))))
-    }
-
-    @Test(expected = ArticleAlreadyInCatalogueException::class)
-    fun `Changing catalogue of article to the same value throws exception`(){
-        articles.setCatalogue(article.id, defaultCatalogue)
-    }
-
-    @Test(expected = ArticleNotFoundException::class)
-    fun `Changing catalogue of non-existent article throws exception`(){
-        articles.setCatalogue("::fake-article-value::", catalogue)
     }
 
     @Test

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
@@ -1,7 +1,6 @@
 package com.tsbonev.nharker.adapter.nitrite
 
 import com.tsbonev.nharker.core.*
-import com.tsbonev.nharker.core.helpers.ReferenceId
 import com.tsbonev.nharker.core.helpers.StubClock
 import com.tsbonev.nharker.core.helpers.append
 import org.dizitart.kno2.filters.eq
@@ -30,24 +29,21 @@ class NitriteCataloguesTest {
             "::firstArticleId::",
             "article-title-1",
             "Article title 1",
-            date,
-            "::catalogue-value::"
+            date
     )
 
     private val secondPresavedArticle = Article(
             "::secondArticleId::",
             "article-title-2",
             "Article title 2",
-            date,
-            "::catalogue-value::"
+            date
     )
 
     private val article = Article(
             "::articleId::",
             "article-title",
             "Article title",
-            date,
-            "::default-catalogue::"
+            date
     )
 
     private val firstPresavedSubcatalogue = Catalogue(
@@ -195,7 +191,7 @@ class NitriteCataloguesTest {
     fun `Remove subcatalogue from catalogue`(){
         val removedCatalogue = catalogues.removeSubCatalogue(catalogue.id, secondPresavedSubcatalogue)
 
-        assertThat(removedCatalogue, Is(secondPresavedSubcatalogue.copy(parentCatalogue = ReferenceId.None.value)))
+        assertThat(removedCatalogue, Is(secondPresavedSubcatalogue.copy(parentCatalogue = null)))
         assertThat(presavedCatalogue().subCatalogues, Is(mapOf(firstPresavedSubcatalogue.id to 0)))
     }
 
@@ -221,7 +217,7 @@ class NitriteCataloguesTest {
     fun `Append article to catalogue`(){
         val appendedChild = catalogues.appendArticle(catalogue.id, article)
 
-        assertThat(appendedChild, Is(article.copy(catalogueId = catalogue.id)))
+        assertThat(appendedChild, Is(article))
         assertThat(presavedCatalogue(), Is(catalogue.copy(articles = catalogue.articles.plus(
                 article.id to catalogue.articles.count()
         ))))
@@ -241,7 +237,7 @@ class NitriteCataloguesTest {
     fun `Remove article from catalogue`(){
         val removedArticle = catalogues.removeArticle(catalogue.id, secondPresavedArticle)
 
-        assertThat(removedArticle, Is(secondPresavedArticle.copy(catalogueId = ReferenceId.None.value)))
+        assertThat(removedArticle, Is(secondPresavedArticle))
         assertThat(presavedCatalogue(), Is(catalogue.copy(articles = mapOf(firstPresavedArticle.id to 0))))
     }
 

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
@@ -23,7 +23,6 @@ class NitriteEntriesTest {
 
     private val entryRequest = EntryRequest(
             "::content::",
-            "::articleId::",
             mapOf("::content::" to "::article::")
     )
 
@@ -34,7 +33,6 @@ class NitriteEntriesTest {
     private val entry = Entry(
             "::entryId::",
             date,
-            "::articleId::",
             "::content::",
             mapOf("::content::" to "::article::")
     )
@@ -101,23 +99,6 @@ class NitriteEntriesTest {
     @Test(expected = EntryNotFoundException::class)
     fun `Updating a non-existent entry's links throws exception`(){
         entries.updateLinks("::fake-entry-value::", mapOf("::new-link::" to "::new-article::"))
-    }
-
-    @Test
-    fun `Change entry article`(){
-        val updatedEntry = entries.changeArticle(entry.id, "::new-article::")
-
-        assertThat(updatedEntry, Is(entry.copy(articleId = "::new-article::")))
-    }
-
-    @Test(expected = EntryNotFoundException::class)
-    fun `Changing entry article of non-existent entry throws exception`(){
-        entries.changeArticle("::fake-entry-value::", entry.articleId)
-    }
-
-    @Test(expected = EntryAlreadyInArticleException::class)
-    fun `Changing entry article with the same article throws exception`(){
-        entries.changeArticle(entry.id, entry.articleId)
     }
 
     @Test


### PR DESCRIPTION
Removed entries reference to articles and article's reference to catalogues.
Made catalogue parents be a nullable string, moved exceptions to proper interfaces.