### PR TITLE
codecov: tweaked yaml file threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,13 +15,14 @@ coverage:
         base: auto
     patch:
       default:
-        enabled: no
-        if_not_found: success
+        target: 75%
+          threshold: 10
+          base: auto
     changes:
       default:
-        enabled: no
-        if_not_found: success
-
+        target: 75%
+          threshold: 10
+          base: auto
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
Codecov no longer fails when a patch has any decrease in test coverage, only when it exceeds 10%.
Closes #53.