### PR TITLE
articles: add queries by link and full title

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -3,6 +3,7 @@ package com.tsbonev.nharker.adapter.nitrite
 import com.tsbonev.nharker.core.*
 import com.tsbonev.nharker.core.helpers.*
 import org.dizitart.kno2.filters.eq
+import org.dizitart.kno2.filters.text
 import org.dizitart.no2.Nitrite
 import org.dizitart.no2.NitriteId
 import org.dizitart.no2.objects.ObjectRepository
@@ -44,6 +45,13 @@ class NitriteArticles(private val nitriteDb: Nitrite,
 
     override fun getById(articleId: String): Optional<Article> {
         val article = coll.find(Article::id eq articleId).firstOrNull()
+                ?: return Optional.empty()
+
+        return Optional.of(article)
+    }
+
+    override fun getByLinkTitle(linkTitle: String): Optional<Article> {
+        val article = coll.find(Article::linkTitle eq linkTitle).firstOrNull()
                 ?: return Optional.empty()
 
         return Optional.of(article)
@@ -117,6 +125,10 @@ class NitriteArticles(private val nitriteDb: Nitrite,
 
         coll.update(article)
         return property
+    }
+
+    override fun searchByFullTitle(searchString: String): List<Article> {
+        return coll.find(Article::fullTitle text searchString).toList()
     }
 
     override fun getArticleTitles(linkTitleList: Set<String>): List<String> {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -97,6 +97,22 @@ interface Articles {
     fun detachProperty(articleId: String, propertyName: String): Entry
 
     /**
+     * Returns an article with a given link title.
+     *
+     * @param linkTitle The link title to search for.
+     * @return An optional article.
+     */
+    fun getByLinkTitle(linkTitle: String): Optional<Article>
+
+    /**
+     * Returns a list of all articles that match a give title.
+     *
+     * @param searchString The string to search by.
+     * @return A list of articles.
+     */
+    fun searchByFullTitle(searchString: String): List<Article>
+
+    /**
      * Returns a list of all article titles that match a set of
      * link titles.
      *

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
@@ -122,8 +122,19 @@ class NitriteArticlesTest {
     }
 
     @Test
-    fun `Return empty when article isn't found`() {
+    fun `Return empty when article isn't found by id`() {
         assertThat(articles.getById("::fake-article-value::").isPresent, Is(false))
+    }
+
+    @Test
+    fun `Retrieve article by link title`(){
+        assertThat(articles.getByLinkTitle(article.linkTitle).isPresent, Is(true))
+        assertThat(articles.getByLinkTitle(article.linkTitle).get(), Is(article))
+    }
+
+    @Test
+    fun `Return empty when article isn't found by link title`(){
+        assertThat(articles.getByLinkTitle("::non-existing-link-title::").isPresent, Is(false))
     }
 
     @Test
@@ -235,6 +246,20 @@ class NitriteArticlesTest {
 
         assertThat(presavedArticle.entries.count(), Is(1))
         assertThat(presavedArticle.entries[secondPresavedEntry.id], Is(0))
+    }
+
+    @Test
+    fun `Retrieve list of articles by querying full titles`(){
+        val articleList = articles.searchByFullTitle(article.fullTitle)
+
+        assertThat(articleList, Is(listOf(article)))
+    }
+
+    @Test
+    fun `Return empty list when no articles match full title search`(){
+        val articleList = articles.searchByFullTitle("Non existent")
+
+        assertThat(articleList, Is(emptyList()))
     }
 
     @Test(expected = ArticleNotFoundException::class)


### PR DESCRIPTION
Added methods to query an exact article by its link title and a group by a search string matched to their full titles.
Closes #101.