### PR TITLE
nharker-core: return updated object when updating

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProvider.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProvider.kt
@@ -54,7 +54,7 @@ class NitriteArticleSynonymProvider(private val nitriteDb: Nitrite,
      * Updates or creates a document object with the global map id
      * and a given map as a value.
      *
-     * @param synonymMap The map whose values to save.
+     * @param synonymMap The map whose ids to save.
      * @return A Document of the map.
      */
     private fun updateOrCreateMap(synonymMap: Map<String, String>): Document {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -1,7 +1,21 @@
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
-import com.tsbonev.nharker.core.helpers.*
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleFullTitle
+import com.tsbonev.nharker.core.ArticleLinkTitle
+import com.tsbonev.nharker.core.ArticleNotFoundException
+import com.tsbonev.nharker.core.ArticleRequest
+import com.tsbonev.nharker.core.ArticleTitleTakenException
+import com.tsbonev.nharker.core.Articles
+import com.tsbonev.nharker.core.Entry
+import com.tsbonev.nharker.core.EntryAlreadyInArticleException
+import com.tsbonev.nharker.core.EntryLinker
+import com.tsbonev.nharker.core.EntryNotInArticleException
+import com.tsbonev.nharker.core.helpers.ElementNotInMapException
+import com.tsbonev.nharker.core.helpers.append
+import com.tsbonev.nharker.core.helpers.subtract
+import com.tsbonev.nharker.core.helpers.switch
+import com.tsbonev.nharker.core.toLinkTitle
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.filters.text
 import org.dizitart.no2.Nitrite
@@ -64,7 +78,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
         return article
     }
 
-    override fun appendEntry(articleId: String, entry: Entry): Entry {
+    override fun appendEntry(articleId: String, entry: Entry): Article {
         val article = findByIdOrThrow(articleId)
 
         if (article.entries.containsKey(entry.id)) throw EntryAlreadyInArticleException()
@@ -76,10 +90,10 @@ class NitriteArticles(private val nitriteDb: Nitrite,
                         .append(entry.id))
 
         coll.update(updatedArticle)
-        return entry
+        return updatedArticle
     }
 
-    override fun removeEntry(articleId: String, entry: Entry): Entry {
+    override fun removeEntry(articleId: String, entry: Entry): Article {
         val article = findByIdOrThrow(articleId)
 
         if (!article.entries.contains(entry.id)) throw EntryNotInArticleException()
@@ -91,7 +105,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
                         .subtract(entry.id))
 
         coll.update(updatedArticle)
-        return entry
+        return updatedArticle
     }
 
     override fun switchEntries(articleId: String, first: Entry, second: Entry): Article {
@@ -109,22 +123,22 @@ class NitriteArticles(private val nitriteDb: Nitrite,
         }
     }
 
-    override fun attachProperty(articleId: String, propertyName: String, property: Entry): Entry {
+    override fun attachProperty(articleId: String, propertyName: String, property: Entry): Article {
         val article = findByIdOrThrow(articleId)
 
         article.properties.attachProperty(propertyName, property)
 
         coll.update(article)
-        return property
+        return article
     }
 
-    override fun detachProperty(articleId: String, propertyName: String): Entry {
+    override fun detachProperty(articleId: String, propertyName: String): Article {
         val article = findByIdOrThrow(articleId)
 
-        val property = article.properties.detachProperty(propertyName)
+        article.properties.detachProperty(propertyName)
 
         coll.update(article)
-        return property
+        return article
     }
 
     override fun searchByFullTitle(searchString: String): List<Article> {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
@@ -1,7 +1,21 @@
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
-import com.tsbonev.nharker.core.helpers.*
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleAlreadyInCatalogueException
+import com.tsbonev.nharker.core.ArticleNotInCatalogueException
+import com.tsbonev.nharker.core.Catalogue
+import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
+import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
+import com.tsbonev.nharker.core.CatalogueNotAChildException
+import com.tsbonev.nharker.core.CatalogueNotFoundException
+import com.tsbonev.nharker.core.CatalogueRequest
+import com.tsbonev.nharker.core.CatalogueTitleTakenException
+import com.tsbonev.nharker.core.Catalogues
+import com.tsbonev.nharker.core.SelfContainedCatalogueException
+import com.tsbonev.nharker.core.helpers.ElementNotInMapException
+import com.tsbonev.nharker.core.helpers.append
+import com.tsbonev.nharker.core.helpers.subtract
+import com.tsbonev.nharker.core.helpers.switch
 import org.dizitart.kno2.filters.eq
 import org.dizitart.no2.Nitrite
 import org.dizitart.no2.NitriteId
@@ -124,7 +138,7 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
         return updatedChild
     }
 
-    override fun appendArticle(parentCatalogueId: String, article: Article): Article {
+    override fun appendArticle(parentCatalogueId: String, article: Article): Catalogue {
         val catalogue = findOrThrow(parentCatalogueId)
 
         if (catalogue.articles.containsKey(article.id)) throw ArticleAlreadyInCatalogueException()
@@ -134,10 +148,10 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
                         .append(article.id))
 
         coll.update(updatedCatalogue)
-        return article
+        return updatedCatalogue
     }
 
-    override fun removeArticle(parentCatalogueId: String, article: Article): Article {
+    override fun removeArticle(parentCatalogueId: String, article: Article): Catalogue {
         val catalogue = findOrThrow(parentCatalogueId)
 
         if (!catalogue.articles.containsKey(article.id)) throw ArticleNotInCatalogueException()
@@ -147,7 +161,7 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
                         .subtract(article.id))
 
         coll.update(updatedCatalogue)
-        return article
+        return updatedCatalogue
     }
 
     override fun switchArticles(catalogueId: String, first: Article, second: Article): Catalogue {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
@@ -1,6 +1,7 @@
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.EntityNotInTrashException
+import com.tsbonev.nharker.core.TrashCollector
 import com.tsbonev.nharker.core.helpers.toDocument
 import com.tsbonev.nharker.core.helpers.toEntity
 import org.dizitart.kno2.filters.eq

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
@@ -1,6 +1,9 @@
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.Entries
+import com.tsbonev.nharker.core.Entry
+import com.tsbonev.nharker.core.EntryNotFoundException
+import com.tsbonev.nharker.core.EntryRequest
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.filters.text
 import org.dizitart.no2.Nitrite

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -32,9 +32,9 @@ interface Articles {
     fun delete(articleId: String): Article
 
     /**
-     * Retrieves an optional article by value.
+     * Retrieves an optional article by id.
      *
-     * @param articleId The value of the article sought.
+     * @param articleId The id of the article sought.
      * @return An optional article.
      */
     fun getById(articleId: String): Optional<Article>
@@ -42,29 +42,29 @@ interface Articles {
     /**
      * Appends an entry to an article.
      *
-     * @param articleId The value of the article targeted.
+     * @param articleId The id of the article targeted.
      * @param entry The entry to append.
-     * @return The updated entry.
+     * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class,
             EntryAlreadyInArticleException::class)
-    fun appendEntry(articleId: String, entry: Entry): Entry
+    fun appendEntry(articleId: String, entry: Entry): Article
 
     /**
-     * Removes an entry from an article, deleting it from persistence.
+     * Removes an entry from an article.
      *
-     * @param articleId The value of the article targeted.
+     * @param articleId The id of the article targeted.
      * @param entry The entry to remove.
-     * @return The removed entry.
+     * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class,
             EntryNotInArticleException::class)
-    fun removeEntry(articleId: String, entry: Entry): Entry
+    fun removeEntry(articleId: String, entry: Entry): Article
 
     /**
      * Switches two entries in an article.
      *
-     * @param articleId The value of the article.
+     * @param articleId The id of the article.
      * @param first The first entry.
      * @param second The second entry.
      * @return The updated article.
@@ -80,21 +80,21 @@ interface Articles {
      * @param articleId: The id of the targeted article.
      * @param propertyName The name of the property.
      * @param property The entry describing the property.
-     * @return The attached property.
+     * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class)
-    fun attachProperty(articleId: String, propertyName: String, property: Entry): Entry
+    fun attachProperty(articleId: String, propertyName: String, property: Entry): Article
 
     /**
      * Detaches a property from an article.
      *
      * @param articleId The id of the targeted article.
      * @param propertyName The name of the property.
-     * @return The removed property.
+     * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class,
             PropertyNotFoundException::class)
-    fun detachProperty(articleId: String, propertyName: String): Entry
+    fun detachProperty(articleId: String, propertyName: String): Article
 
     /**
      * Returns an article with a given link title.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
@@ -24,17 +24,17 @@ interface Catalogues {
     fun save(catalogue: Catalogue): Catalogue
 
     /**
-     * Retrieves an article by value.
+     * Retrieves an article by id.
      *
-     * @param catalogueId The value search by.
+     * @param catalogueId The id to search by.
      * @return An optional article.
      */
     fun getById(catalogueId: String): Optional<Catalogue>
 
     /**
-     * Deletes a catalogue by value.
+     * Deletes a catalogue by id.
      *
-     * @param catalogueId The value of the catalogue targeted.
+     * @param catalogueId The id of the catalogue targeted.
      * @return The deleted catalogue.
      */
     @Throws(CatalogueNotFoundException::class)
@@ -43,7 +43,7 @@ interface Catalogues {
     /**
      * Changes the title of a catalogue.
      *
-     * @param catalogueId The value of the catalogue targeted.
+     * @param catalogueId The id of the catalogue targeted.
      * @param newTitle The new title.
      * @return The updated catalogue.
      */
@@ -88,29 +88,29 @@ interface Catalogues {
     /**
      * Appends an article from a catalogue.
      *
-     * @param parentCatalogueId The value of the catalogue targeted.
+     * @param parentCatalogueId The id of the catalogue targeted.
      * @param article The article.
-     * @return The appended article.
+     * @return The updated catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
             ArticleAlreadyInCatalogueException::class)
-    fun appendArticle(parentCatalogueId: String, article: Article): Article
+    fun appendArticle(parentCatalogueId: String, article: Article): Catalogue
 
     /**
      * Removes an article from a catalogue.
      *
-     * @param parentCatalogueId The value of the catalogue targeted.
-     * @param article The  article.
-     * @return The removed article.
+     * @param parentCatalogueId The id of the catalogue targeted.
+     * @param article The  article to remove.
+     * @return The updated catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
             ArticleNotInCatalogueException::class)
-    fun removeArticle(parentCatalogueId: String, article: Article): Article
+    fun removeArticle(parentCatalogueId: String, article: Article): Catalogue
 
     /**
      * Switches the order of two articles in a catalogue.
      *
-     * @param catalogueId The value of the catalogue targeted.
+     * @param catalogueId The id of the catalogue targeted.
      * @param first The first article.
      * @param second The second article.
      * @return The updated catalogue.
@@ -122,7 +122,7 @@ interface Catalogues {
     /**
      * Switches the order of two subcatalogues in a catalogue.
      *
-     * @param parentCatalogueId The value of the catalogue targeted.
+     * @param parentCatalogueId The id of the catalogue targeted.
      * @param firstChild The first catalogue.
      * @param secondChild The second catalogue.
      * @return The updated catalogue.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
@@ -34,7 +34,7 @@ interface Entries {
     /**
      * Updates the content of an entry.
      *
-     * @param entryId The value of the entry targeted.
+     * @param entryId The id of the entry targeted.
      * @param content The new content of the entry.
      * @return The updated entry.
      */
@@ -44,7 +44,7 @@ interface Entries {
     /**
      * Updates the links of an entry.
      *
-     * @param entryId The value of the entry targeted.
+     * @param entryId The id of the entry targeted.
      * @param links The new links of the entry.
      * @return The updated entry.
      */
@@ -52,9 +52,9 @@ interface Entries {
     fun updateLinks(entryId: String, links: Map<String, String>): Entry
 
     /**
-     * Returns an optional entry by value.
+     * Returns an optional entry by id.
      *
-     * @param entryId The value of the entry sought.
+     * @param entryId The id of the entry sought.
      * @return An optional entry.
      */
     fun getById(entryId: String): Optional<Entry>

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/StubClock.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/StubClock.kt
@@ -1,6 +1,9 @@
 package com.tsbonev.nharker.core.helpers
 
-import java.time.*
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProviderTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProviderTest.kt
@@ -6,12 +6,11 @@ import com.tsbonev.nharker.core.SynonymNotFoundException
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.nitrite
 import org.dizitart.no2.Document
-import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Test
-import org.hamcrest.CoreMatchers.`is` as Is
 import org.junit.Assert.assertThat
 import org.junit.Before
+import org.junit.Test
 import java.time.LocalDateTime
+import org.hamcrest.CoreMatchers.`is` as Is
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
@@ -1,18 +1,28 @@
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleAlreadyInCatalogueException
+import com.tsbonev.nharker.core.ArticleNotInCatalogueException
+import com.tsbonev.nharker.core.Catalogue
+import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
+import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
+import com.tsbonev.nharker.core.CatalogueNotAChildException
+import com.tsbonev.nharker.core.CatalogueNotFoundException
+import com.tsbonev.nharker.core.CatalogueRequest
+import com.tsbonev.nharker.core.CatalogueTitleTakenException
+import com.tsbonev.nharker.core.SelfContainedCatalogueException
 import com.tsbonev.nharker.core.helpers.StubClock
 import com.tsbonev.nharker.core.helpers.append
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.nitrite
 import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
-import java.time.LocalDateTime
-import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Assert.assertThat
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneOffset
+import org.hamcrest.CoreMatchers.`is` as Is
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
@@ -47,21 +57,21 @@ class NitriteCataloguesTest {
     )
 
     private val firstPresavedSubcatalogue = Catalogue(
-            "::catalogue-value-1::",
+            "::catalogue-id-1::",
             "::catalogue-title-1::",
             date,
-            parentCatalogue = "::catalogue-value::"
+            parentCatalogue = "::catalogue-id::"
     )
 
     private val secondPresavedSubcatalogue = Catalogue(
-            "::catalogue-value-2::",
+            "::catalogue-id-2::",
             "::catalogue-title-2::",
             date,
-            parentCatalogue = "::catalogue-value::"
+            parentCatalogue = "::catalogue-id::"
     )
 
     private val subCatalogue = Catalogue(
-            "::catalogue-value-3::",
+            "::catalogue-id-3::",
             "::catalogue-title-3::",
             date
     )
@@ -71,7 +81,7 @@ class NitriteCataloguesTest {
     )
 
     private val catalogue = Catalogue(
-            "::catalogue-value::",
+            "::catalogue-id::",
             "::catalogue-title::",
             date,
             mapOf(firstPresavedArticle.id to 0,
@@ -127,7 +137,7 @@ class NitriteCataloguesTest {
 
     @Test
     fun `Retrieving non-existent catalogue returns empty`() {
-        assertThat(catalogues.getById("fake-catalogue-value::").isPresent, Is(false))
+        assertThat(catalogues.getById("fake-catalogue-id::").isPresent, Is(false))
     }
 
     @Test
@@ -145,7 +155,7 @@ class NitriteCataloguesTest {
 
     @Test(expected = CatalogueNotFoundException::class)
     fun `Changing title of non-existent catalogue throws exception`() {
-        catalogues.changeTitle("::fake-value::", catalogue.title)
+        catalogues.changeTitle("::fake-id::", catalogue.title)
     }
 
     @Test
@@ -236,12 +246,9 @@ class NitriteCataloguesTest {
 
     @Test
     fun `Append article to catalogue`() {
-        val appendedChild = catalogues.appendArticle(catalogue.id, article)
+        val updatedCatalogue = catalogues.appendArticle(catalogue.id, article)
 
-        assertThat(appendedChild, Is(article))
-        assertThat(presavedCatalogue, Is(catalogue.copy(articles = catalogue.articles.plus(
-                article.id to catalogue.articles.count()
-        ))))
+        assertThat(presavedCatalogue, Is(updatedCatalogue))
     }
 
     @Test(expected = ArticleAlreadyInCatalogueException::class)
@@ -251,15 +258,14 @@ class NitriteCataloguesTest {
 
     @Test(expected = CatalogueNotFoundException::class)
     fun `Appending article to non-existent catalogue throws exception`() {
-        catalogues.appendArticle("::fake-catalogue-value::", article)
+        catalogues.appendArticle("::fake-catalogue-id::", article)
     }
 
     @Test
     fun `Remove article from catalogue`() {
-        val removedArticle = catalogues.removeArticle(catalogue.id, secondPresavedArticle)
+        val updatedCatalogue = catalogues.removeArticle(catalogue.id, secondPresavedArticle)
 
-        assertThat(removedArticle, Is(secondPresavedArticle))
-        assertThat(presavedCatalogue, Is(catalogue.copy(articles = mapOf(firstPresavedArticle.id to 0))))
+        assertThat(presavedCatalogue, Is(updatedCatalogue))
     }
 
     @Test
@@ -293,7 +299,7 @@ class NitriteCataloguesTest {
 
     @Test(expected = CatalogueNotFoundException::class)
     fun `Switching articles in non-existent catalogue throws exception`() {
-        catalogues.switchArticles("::fake-catalogue-value::",
+        catalogues.switchArticles("::fake-catalogue-id::",
                 firstPresavedArticle, secondPresavedArticle)
     }
 
@@ -320,7 +326,7 @@ class NitriteCataloguesTest {
 
     @Test(expected = CatalogueNotFoundException::class)
     fun `Switching subcatalogues in non-existing catalogue throws exception`() {
-        catalogues.switchSubCatalogues("::fake-catalogue-value::",
+        catalogues.switchSubCatalogues("::fake-catalogue-id::",
                 firstPresavedSubcatalogue, secondPresavedSubcatalogue)
     }
 
@@ -339,6 +345,6 @@ class NitriteCataloguesTest {
 
     @Test(expected = CatalogueNotFoundException::class)
     fun `Deleting non-existent catalogue throws exception`() {
-        catalogues.delete("::fake-catalogue-value::")
+        catalogues.delete("::fake-catalogue-id::")
     }
 }

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
@@ -2,19 +2,22 @@
 
 package com.tsbonev.nharker.adapter.nitrite
 
-import com.tsbonev.nharker.core.*
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleProperties
+import com.tsbonev.nharker.core.EntityNotInTrashException
+import com.tsbonev.nharker.core.Entry
 import com.tsbonev.nharker.core.helpers.toDocument
 import com.tsbonev.nharker.core.helpers.toEntity
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.nitrite
 import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
+import org.junit.Before
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Assert.assertThat
-import org.junit.Before
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
@@ -1,18 +1,17 @@
 package com.tsbonev.nharker.adapter.nitrite
 
 import com.tsbonev.nharker.core.Entry
-import com.tsbonev.nharker.core.EntryAlreadyInArticleException
 import com.tsbonev.nharker.core.EntryNotFoundException
 import com.tsbonev.nharker.core.EntryRequest
 import com.tsbonev.nharker.core.helpers.StubClock
 import org.dizitart.kno2.nitrite
-import org.junit.Test
-import java.time.LocalDateTime
-import org.hamcrest.CoreMatchers.`is` as Is
 import org.junit.Assert.assertThat
 import org.junit.Before
+import org.junit.Test
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneOffset
+import org.hamcrest.CoreMatchers.`is` as Is
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
@@ -64,7 +63,7 @@ class NitriteEntriesTest {
 
     @Test
     fun `Return empty when an entry is not found by id`() {
-        val retrievedEntry = entries.getById("::fake-entry-value::")
+        val retrievedEntry = entries.getById("::fake-entry-id::")
 
         assertThat(retrievedEntry.isPresent, Is(false))
     }
@@ -82,7 +81,7 @@ class NitriteEntriesTest {
 
     @Test(expected = EntryNotFoundException::class)
     fun `Updating a non-existent entry's content throws exception`() {
-        entries.updateContent("::fake-entry-value::", "::content::")
+        entries.updateContent("::fake-entry-id::", "::content::")
     }
 
     @Test
@@ -98,7 +97,7 @@ class NitriteEntriesTest {
 
     @Test(expected = EntryNotFoundException::class)
     fun `Updating a non-existent entry's links throws exception`() {
-        entries.updateLinks("::fake-entry-value::", mapOf("::new-link::" to "::new-article::"))
+        entries.updateLinks("::fake-entry-id::", mapOf("::new-link::" to "::new-article::"))
     }
 
     @Test
@@ -130,6 +129,6 @@ class NitriteEntriesTest {
 
     @Test(expected = EntryNotFoundException::class)
     fun `Deleting non-existent entry throws exception`() {
-        entries.delete("::fake-entry-value::")
+        entries.delete("::fake-entry-id::")
     }
 }

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/SimpleEntryLinkerTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/SimpleEntryLinkerTest.kt
@@ -4,11 +4,11 @@ import org.jmock.AbstractExpectations.returnValue
 import org.jmock.Expectations
 import org.jmock.Mockery
 import org.jmock.integration.junit4.JUnitRuleMockery
+import org.junit.Assert.assertThat
+import org.junit.Rule
 import org.junit.Test
 import java.time.LocalDateTime
 import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Assert.assertThat
-import org.junit.Rule
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedMapHelpersTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedMapHelpersTest.kt
@@ -1,8 +1,8 @@
 package com.tsbonev.nharker.core.helpers
 
+import org.junit.Assert.assertThat
 import org.junit.Test
 import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Assert.assertThat
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
@@ -35,12 +35,12 @@ class OrderedMapHelpersTest {
     }
 
     @Test(expected = ElementNotInMapException::class)
-    fun `Subtracting non-existent value throws exception`() {
-        mutableMap.subtract("::non-existent-value::")
+    fun `Subtracting non-existent id throws exception`() {
+        mutableMap.subtract("::non-existent-id::")
     }
 
     @Test
-    fun `Switching list values reorders`() {
+    fun `Switching list ids reorders`() {
         holderMap = mutableMap.append("One")
         holderMap = holderMap.append("Two")
         holderMap = holderMap.append("Three")
@@ -53,7 +53,7 @@ class OrderedMapHelpersTest {
     }
 
     @Test(expected = ElementNotInMapException::class)
-    fun `Switching non-existent value throws exception`() {
-        mutableMap.switch("::non-existent-value::", "::non-existent-value::")
+    fun `Switching non-existent id throws exception`() {
+        mutableMap.switch("::non-existent-id::", "::non-existent-id::")
     }
 }

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/StubClockTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/StubClockTest.kt
@@ -1,9 +1,12 @@
 package com.tsbonev.nharker.core.helpers
 
-import org.junit.Test
-import org.hamcrest.CoreMatchers.`is` as Is
 import org.junit.Assert.assertThat
-import java.time.*
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import org.hamcrest.CoreMatchers.`is` as Is
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)


### PR DESCRIPTION
Fixed some weird thing that caused most ids to be renamed to values.
Refactored repositories to now return the updated object instead of just throwing back the passed parameter.
Closes #103.