### PR TITLE
nhraker-core: add check for parent during catalogue creation

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
@@ -14,14 +14,14 @@ import java.time.LocalDateTime
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-@Indices(Index(value = "parentCatalogue", type = IndexType.NonUnique),
+@Indices(Index(value = "parentId", type = IndexType.NonUnique),
         Index(value = "title", type = IndexType.Unique))
 data class Catalogue(@Id val id: String,
                      val title: String,
                      val creationDate: LocalDateTime,
                      val articles: Map<String, Int> = emptyMap(),
                      val subCatalogues: Map<String, Int> = emptyMap(),
-                     val parentCatalogue: String? = null)
+                     val parentId: String? = null)
 
 class CatalogueNotFoundException : Throwable()
 class CatalogueTitleTakenException : Throwable()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
@@ -4,4 +4,4 @@ package com.tsbonev.nharker.core
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class CatalogueRequest(val title: String,
-                            val parentCatalogue: String? = null)
+                            val parentId: String? = null)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
@@ -14,7 +14,8 @@ interface Catalogues {
      * @param catalogueRequest The requested catalogue.
      * @return The created catalogue.
      */
-    @Throws(CatalogueTitleTakenException::class)
+    @Throws(CatalogueTitleTakenException::class,
+            CatalogueNotFoundException::class)
     fun create(catalogueRequest: CatalogueRequest): Catalogue
 
     /**
@@ -55,7 +56,7 @@ interface Catalogues {
      * Changes the parent of a catalogue.
      *
      * @param childCatalogueId The id of the catalogue targeted.
-     * @param parentCatalogue The id of the new parent.
+     * @param parentCatalogue The new parent.
      * @return The updated child catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
@@ -66,7 +67,7 @@ interface Catalogues {
      * Appends a catalogue to the targeted catalogue's children list.
      *
      * @param parentCatalogueId The id of the targeted parent catalogue.
-     * @param childCatalogue The id of the child catalogue.
+     * @param childCatalogue The child catalogue to append.
      * @return The updated parent catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
@@ -78,7 +79,7 @@ interface Catalogues {
      * Removes a catalogue from the targeted catalogue's children list.
      *
      * @param parentCatalogueId The id of the parent catalogue.
-     * @param childCatalogue The id of the child catalogue.
+     * @param childCatalogue The child catalogue to remove.
      * @return The updated parent catalogue.
      */
     @Throws(CatalogueNotFoundException::class,
@@ -89,7 +90,7 @@ interface Catalogues {
      * Appends an article from a catalogue.
      *
      * @param parentCatalogueId The id of the catalogue targeted.
-     * @param article The article.
+     * @param article The article to append.
      * @return The updated catalogue.
      */
     @Throws(CatalogueNotFoundException::class,

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
@@ -60,14 +60,14 @@ class NitriteCataloguesTest {
             "::catalogue-id-1::",
             "::catalogue-title-1::",
             date,
-            parentCatalogue = "::catalogue-id::"
+            parentId = "::catalogue-id::"
     )
 
     private val secondPresavedSubcatalogue = Catalogue(
             "::catalogue-id-2::",
             "::catalogue-title-2::",
             date,
-            parentCatalogue = "::catalogue-id::"
+            parentId = "::catalogue-id::"
     )
 
     private val subCatalogue = Catalogue(
@@ -122,6 +122,11 @@ class NitriteCataloguesTest {
         catalogues.create(catalogueRequest)
     }
 
+    @Test(expected = CatalogueNotFoundException::class)
+    fun `Creating a catalogue with a non-existent parent throws exception`(){
+        catalogues.create(CatalogueRequest("::new-catalogue::", "::non-existent-parent-id::"))
+    }
+
     @Test
     fun `Save and return catalogue`() {
         db.getRepository(collectionName, Catalogue::class.java).remove(Catalogue::id eq catalogue.id)
@@ -163,7 +168,7 @@ class NitriteCataloguesTest {
         val updatedChild = catalogues.changeParentCatalogue(subCatalogue.id, catalogue)
 
         assertThat(updatedChild, Is(subCatalogue.copy(
-                parentCatalogue = catalogue.id)))
+                parentId = catalogue.id)))
         assertThat(presavedCatalogue, Is(catalogue.copy(
                 subCatalogues = catalogue.subCatalogues.append(subCatalogue.id))))
     }
@@ -192,7 +197,7 @@ class NitriteCataloguesTest {
     fun `Append catalogue to catalogue subcatalogues`() {
         val appendedChild = catalogues.appendSubCatalogue(catalogue.id, subCatalogue)
 
-        assertThat(appendedChild, Is(subCatalogue.copy(parentCatalogue = catalogue.id)))
+        assertThat(appendedChild, Is(subCatalogue.copy(parentId = catalogue.id)))
         assertThat(presavedCatalogue, Is(catalogue.copy(subCatalogues = catalogue.subCatalogues.plus(
                 subCatalogue.id to catalogue.subCatalogues.count()
         ))))
@@ -222,7 +227,7 @@ class NitriteCataloguesTest {
     fun `Remove subcatalogue from catalogue`() {
         val removedCatalogue = catalogues.removeSubCatalogue(catalogue.id, secondPresavedSubcatalogue)
 
-        assertThat(removedCatalogue, Is(secondPresavedSubcatalogue.copy(parentCatalogue = null)))
+        assertThat(removedCatalogue, Is(secondPresavedSubcatalogue.copy(parentId = null)))
         assertThat(presavedCatalogue.subCatalogues, Is(mapOf(firstPresavedSubcatalogue.id to 0)))
     }
 


### PR DESCRIPTION
Added a check that throws CatalogueNotFound when a catalogue is requested with a non-existing parent id.
Fixed some misleading comments in the catalogue interface and renamed parentCatalogue to parentId for better clarity of the catalogue object.
Closes #110.