### PR TITLE
nharker-server: add synonym workflow

### DIFF
--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/ArticleSynonymWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/ArticleSynonymWorkflow.kt
@@ -1,0 +1,153 @@
+package com.tsbonev.nharker.server.workflow
+
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleSynonymProvider
+import com.tsbonev.nharker.core.SynonymAlreadyTakenException
+import com.tsbonev.nharker.core.SynonymNotFoundException
+import com.tsbonev.nharker.cqrs.Command
+import com.tsbonev.nharker.cqrs.CommandHandler
+import com.tsbonev.nharker.cqrs.CommandResponse
+import com.tsbonev.nharker.cqrs.Event
+import com.tsbonev.nharker.cqrs.EventBus
+import com.tsbonev.nharker.cqrs.EventHandler
+import com.tsbonev.nharker.cqrs.Workflow
+import com.tsbonev.nharker.server.helpers.HttpStatus
+import org.slf4j.LoggerFactory
+
+/**
+ * Provides the command handlers that are concerned with the
+ * direct state of the global synonym map.
+ *
+ * Provides the event handlers that update the global synonym
+ * map.
+ *
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class ArticleSynonymWorkflow(private val eventBus: EventBus,
+                             private val synonyms: ArticleSynonymProvider) : Workflow {
+    private val logger = LoggerFactory.getLogger("ArticleSynonymWorkflow")
+
+    //region Command Handlers
+    /**
+     * Adds a synonym to the global map.
+     * @code 201
+     * @payload A pair of the added synonym and its article.
+     * @publishes SynonymAddedEvent
+     *
+     * If the synonym is already taken, logs the name of the synonym.
+     * @code 400
+     */
+    fun addSynonym(command: AddSynonymCommand): CommandResponse {
+        return try {
+            val addedSynonym = synonyms.addSynonym(command.synonym, command.article)
+            eventBus.publish(SynonymAddedEvent(addedSynonym, command.article))
+
+            return CommandResponse(HttpStatus.Created.value, Pair(addedSynonym, command.article))
+        } catch (e: SynonymAlreadyTakenException) {
+            logger.error("The synonym ${command.synonym} is already present in the synonym map!")
+            CommandResponse(HttpStatus.BadRequest.value)
+        }
+    }
+
+    /**
+     * Removes a synonym from the global synonym map.
+     * @code 200
+     * @payload The removed synonym.
+     * @publishes SynonymRemovedEvent
+     *
+     * If the synonym is not found, logs the synonym name.
+     * @code 404
+     */
+    fun removeSynonym(command: RemoveSynonymCommand): CommandResponse {
+        return try {
+            val removedSynonym = synonyms.removeSynonym(command.synonym)
+            eventBus.publish(SynonymRemovedEvent(removedSynonym))
+
+            return CommandResponse(HttpStatus.OK.value, removedSynonym)
+        } catch (e: SynonymNotFoundException) {
+            logger.error("The synonym ${command.synonym} was not found in the map")
+            CommandResponse(HttpStatus.NotFound.value)
+        }
+    }
+
+    /**
+     * Returns the whole global synonym map.
+     * @code 200
+     * @payload A map of synonyms and article link titles.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    @CommandHandler
+    fun getSynonymMap(command: GetSynonymMapCommand): CommandResponse {
+        return CommandResponse(HttpStatus.OK.value, synonyms.getSynonymMap())
+    }
+
+    /**
+     * Returns a list of synonyms associated with an article.
+     * @code 200
+     * @payload A list of synonyms.
+     */
+    @CommandHandler
+    fun getSynonymsForArticle(command: GetSynonymsForArticleCommand): CommandResponse {
+        val synonymList = mutableListOf<String>()
+
+        synonyms.getSynonymMap()
+                .filter { it.value == command.article.linkTitle }
+                .mapTo(synonymList) { it.key }
+
+        return CommandResponse(HttpStatus.OK.value, synonymList)
+    }
+
+    /**
+     * Searches for a synonym in the global synonym map.
+     * @code 200
+     * @payload The found article link title to which the synonym points.
+     *
+     * If no synonym matches the search string, returns not found.
+     * @code 404
+     */
+    @CommandHandler
+    fun searchSynonymMap(command: SearchSynonymMapCommand): CommandResponse {
+        val foundLink = synonyms.getSynonymMap()[command.searchString]
+
+        return if (foundLink != null) {
+            CommandResponse(HttpStatus.OK.value, foundLink)
+        } else {
+            CommandResponse(HttpStatus.NotFound.value)
+        }
+    }
+    //endregion
+
+    //region Event Handlers
+    /**
+     * Removes the synonyms of a deleted article.
+     * @publishes SynonymRemovedEvent
+     */
+    @EventHandler
+    fun onArticleDeletedRemoveSynonyms(event: ArticleDeletedEvent) {
+        synonyms.getSynonymMap()
+                .filter { it.value == event.article.linkTitle }
+                .forEach { key, _ ->
+                    synonyms.removeSynonym(key)
+                    eventBus.publish(SynonymRemovedEvent(key))
+                }
+    }
+    //endregion
+}
+
+//region Queries
+
+class GetSynonymMapCommand : Command
+data class GetSynonymsForArticleCommand(val article: Article) : Command
+data class SearchSynonymMapCommand(val searchString: String) : Command
+
+//endregion
+
+//region Commands
+
+data class AddSynonymCommand(val synonym: String, val article: Article) : Command
+data class SynonymAddedEvent(val synonym: String, val article: Article) : Event
+
+data class RemoveSynonymCommand(val synonym: String) : Command
+data class SynonymRemovedEvent(val synonym: String) : Event
+
+//endregion

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleSynonymWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleSynonymWorkflowTest.kt
@@ -1,0 +1,203 @@
+package com.tsbonev.nharker.server.workflow
+import com.tsbonev.nharker.core.Article
+import com.tsbonev.nharker.core.ArticleSynonymProvider
+import com.tsbonev.nharker.core.SynonymAlreadyTakenException
+import com.tsbonev.nharker.core.SynonymNotFoundException
+import com.tsbonev.nharker.cqrs.EventBus
+import com.tsbonev.nharker.server.helpers.HttpStatus
+import org.jmock.AbstractExpectations.returnValue
+import org.jmock.AbstractExpectations.throwException
+import org.jmock.Expectations
+import org.jmock.Mockery
+import org.jmock.integration.junit4.JUnitRuleMockery
+import org.hamcrest.CoreMatchers.`is` as Is
+import org.junit.Assert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDateTime
+
+@Suppress("UNCHECKED_CAST")
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class ArticleSynonymWorkflowTest{
+
+    @Rule
+    @JvmField
+    val context: JUnitRuleMockery = JUnitRuleMockery()
+
+    private val article = Article(
+            "::id::",
+            "link-title",
+            "full-title",
+            LocalDateTime.now()
+    )
+
+    private val eventBus = context.mock(EventBus::class.java)
+    private val synonymProvider = context.mock(ArticleSynonymProvider::class.java)
+
+    private val synonymWorkflow = ArticleSynonymWorkflow(eventBus, synonymProvider)
+
+    @Test
+    fun `Retrieve full global map`(){
+        val synonymMap = mapOf("::synonym::" to "::link-title::")
+
+        context.expecting {
+            oneOf(synonymProvider).getSynonymMap()
+            will(returnValue(synonymMap))
+        }
+
+        val response = synonymWorkflow.getSynonymMap(GetSynonymMapCommand())
+
+        assertThat(response.statusCode, Is(HttpStatus.OK.value))
+        assertThat(response.payload.isPresent, Is(true))
+        assertThat(response.payload.get() as Map<String, String>, Is(synonymMap))
+    }
+
+    @Test
+    fun `Search synonym map`(){
+        val synonymMap = mapOf("::synonym::" to "::link-title::")
+
+        context.expecting {
+            oneOf(synonymProvider).getSynonymMap()
+            will(returnValue(synonymMap))
+        }
+
+        val response = synonymWorkflow.searchSynonymMap(
+                SearchSynonymMapCommand("::synonym::"))
+
+        assertThat(response.statusCode, Is(HttpStatus.OK.value))
+        assertThat(response.payload.isPresent, Is(true))
+        assertThat(response.payload.get() as String, Is("::link-title::"))
+    }
+
+    @Test
+    fun `Searching synonym map for non-existent synonym returns not found`(){
+        val synonymMap = mapOf("::synonym::" to "::link-title::")
+
+        context.expecting {
+            oneOf(synonymProvider).getSynonymMap()
+            will(returnValue(synonymMap))
+        }
+
+        val response = synonymWorkflow.searchSynonymMap(
+                SearchSynonymMapCommand("::non-existing-synonym::"))
+
+        assertThat(response.statusCode, Is(HttpStatus.NotFound.value))
+        assertThat(response.payload.isPresent, Is(false))
+    }
+
+    @Test
+    fun `Get article synonyms`(){
+        val synonym = "::synonym::"
+        val synonymMap = mapOf(synonym to article.linkTitle)
+
+        context.expecting {
+            oneOf(synonymProvider).getSynonymMap()
+            will(returnValue(synonymMap))
+        }
+
+        val response = synonymWorkflow.getSynonymsForArticle(
+                GetSynonymsForArticleCommand(article))
+
+        assertThat(response.statusCode, Is(HttpStatus.OK.value))
+        assertThat(response.payload.isPresent, Is(true))
+        assertThat(response.payload.get() as List<String>, Is(listOf(synonym)))
+    }
+
+    @Test
+    fun `Adding synonym returns pair of synonym and article`(){
+        val synonym = "::synonym::"
+
+        context.expecting {
+            oneOf(synonymProvider).addSynonym(synonym, article)
+            will(returnValue(synonym))
+
+            oneOf(eventBus).publish(SynonymAddedEvent(synonym, article))
+        }
+
+        val response = synonymWorkflow.addSynonym(
+                AddSynonymCommand(synonym, article))
+
+        assertThat(response.statusCode, Is(HttpStatus.Created.value))
+        assertThat(response.payload.isPresent, Is(true))
+        assertThat(response.payload.get() as Pair<String, Article>, Is(Pair(synonym, article)))
+    }
+
+    @Test
+    fun `Adding synonym that already exists returns bad request`(){
+        val synonym = "::synonym::"
+
+        context.expecting {
+            oneOf(synonymProvider).addSynonym(synonym, article)
+            will(throwException(SynonymAlreadyTakenException()))
+        }
+
+        val response = synonymWorkflow.addSynonym(
+                AddSynonymCommand(synonym, article))
+
+        assertThat(response.statusCode, Is(HttpStatus.BadRequest.value))
+        assertThat(response.payload.isPresent, Is(false))
+    }
+
+    @Test
+    fun `Removing synonym returns it`(){
+        val synonym = "::synonym::"
+
+        context.expecting {
+            oneOf(synonymProvider).removeSynonym(synonym)
+            will(returnValue(synonym))
+
+            oneOf(eventBus).publish(SynonymRemovedEvent(synonym))
+        }
+
+        val response = synonymWorkflow.removeSynonym(
+                RemoveSynonymCommand(synonym))
+
+        assertThat(response.statusCode, Is(HttpStatus.OK.value))
+        assertThat(response.payload.isPresent, Is(true))
+        assertThat(response.payload.get() as String, Is(synonym))
+    }
+
+    @Test
+    fun `Removing non-existent synonym returns not found`(){
+        val synonym = "::synonym::"
+
+        context.expecting {
+            oneOf(synonymProvider).removeSynonym(synonym)
+            will(throwException(SynonymNotFoundException()))
+        }
+
+        val response = synonymWorkflow.removeSynonym(
+                RemoveSynonymCommand(synonym))
+
+        assertThat(response.statusCode, Is(HttpStatus.NotFound.value))
+        assertThat(response.payload.isPresent, Is(false))
+    }
+
+    @Test
+    fun `Deleted articles get synonyms removed`(){
+        val firstSynonym = "::first-synonym::"
+        val secondSynonym = "::second-synonym::"
+
+        val synonymMap = mapOf(firstSynonym to article.linkTitle,
+                secondSynonym to article.linkTitle)
+
+        context.expecting {
+            oneOf(synonymProvider).getSynonymMap()
+            will(returnValue(synonymMap))
+
+            oneOf(synonymProvider).removeSynonym(firstSynonym)
+            oneOf(eventBus).publish(SynonymRemovedEvent(firstSynonym))
+
+            oneOf(synonymProvider).removeSynonym(secondSynonym)
+            oneOf(eventBus).publish(SynonymRemovedEvent(secondSynonym))
+        }
+
+        synonymWorkflow.onArticleDeletedRemoveSynonyms(ArticleDeletedEvent(article))
+    }
+
+    private fun Mockery.expecting(block: Expectations.() -> Unit){
+            checking(Expectations().apply(block))
+    }
+}


### PR DESCRIPTION
Added a synonym workflow that handles article deletion events and queries/commands concerning the global synonym map.
Closes #109.