### PR TITLE
nharker-core: save trashed domain objects with own id

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollector.kt
@@ -1,5 +1,6 @@
 package com.tsbonev.nharker.adapter.nitrite
 
+import com.tsbonev.nharker.core.Entity
 import com.tsbonev.nharker.core.EntityCannotBeCastException
 import com.tsbonev.nharker.core.EntityNotInTrashException
 import com.tsbonev.nharker.core.TrashCollector
@@ -30,7 +31,7 @@ class NitriteEntityTrashCollector(private val nitriteDb: Nitrite,
         return entityList
     }
 
-    override fun trash(entity: Any): String {
+    override fun trash(entity: Entity): String {
 
         val documentEntity = entity.toDocument()
 

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
@@ -16,13 +16,13 @@ import java.time.LocalDateTime
  */
 @Indices(Index(value = "linkTitle", type = IndexType.NonUnique),
         Index(value = "fullTitle", type = IndexType.Fulltext))
-data class Article(@Id val id: String,
+data class Article(@Id override val id: String,
                    val linkTitle: String,
                    val fullTitle: String,
-                   val creationDate: LocalDateTime,
+                   override val creationDate: LocalDateTime,
                    val properties: ArticleProperties = ArticleProperties(),
                    val entries: Map<String, Int> = emptyMap(),
-                   val links: ArticleLinks = ArticleLinks(mutableMapOf()))
+                   val links: ArticleLinks = ArticleLinks(mutableMapOf())) : Entity
 
 /**
  * Converts a full text title to a lowercase, dash-concatenated string.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
@@ -16,12 +16,12 @@ import java.time.LocalDateTime
  */
 @Indices(Index(value = "parentId", type = IndexType.NonUnique),
         Index(value = "title", type = IndexType.Unique))
-data class Catalogue(@Id val id: String,
+data class Catalogue(@Id override val id: String,
                      val title: String,
-                     val creationDate: LocalDateTime,
+                     override val creationDate: LocalDateTime,
                      val articles: Map<String, Int> = emptyMap(),
                      val subCatalogues: Map<String, Int> = emptyMap(),
-                     val parentId: String? = null)
+                     val parentId: String? = null) : Entity
 
 class CatalogueNotFoundException(val catalogueId: String) : Throwable()
 class CatalogueTitleTakenException(val catalogueTitle: String) : Throwable()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
@@ -1,0 +1,14 @@
+package com.tsbonev.nharker.core
+
+import java.time.LocalDateTime
+
+/**
+ * Defines what a Domain Entity must contain to
+ * be considered a Domain Entity.
+ *
+ * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ */
+interface Entity {
+    val id: String
+    val creationDate: LocalDateTime
+}

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
@@ -15,9 +15,9 @@ import java.time.LocalDateTime
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 @Indices(Index(value = "content", type = IndexType.Fulltext))
-data class Entry(@Id val id: String,
-                 val creationDate: LocalDateTime,
+data class Entry(@Id override val id: String,
+                 override val creationDate: LocalDateTime,
                  val content: String,
-                 val links: Map<String, String> = emptyMap())
+                 val links: Map<String, String> = emptyMap()) : Entity
 
 class EntryNotFoundException(val entryId: String) : Throwable()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/TrashCollector.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/TrashCollector.kt
@@ -19,10 +19,10 @@ interface TrashCollector {
     /**
      * Stores an entity into the trash collection.
      *
-     * @param entity Entity to trash.
+     * @param entity The entity to trash.
      * @return The id of the trashed entity.
      */
-    fun trash(entity: Any): String
+    fun trash(entity: Entity): String
 
     /**
      * Retrieves an entity from the trash.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
@@ -1,8 +1,8 @@
 package com.tsbonev.nharker.core.helpers
 
 import com.google.gson.Gson
+import com.tsbonev.nharker.core.Entity
 import org.dizitart.no2.Document
-import org.dizitart.no2.NitriteId
 
 /**
  * Converters used by the trash store.
@@ -11,12 +11,12 @@ import org.dizitart.no2.NitriteId
  */
 
 /**
- * Converts object to a document with three fields:
+ * Converts an entity to a document with three fields:
  * a class, an id and a json body.
  */
-fun Any.toDocument(): Document {
+fun Entity.toDocument(): Document {
     val document = Document()
-    document["entityId"] = NitriteId.newId().toString()
+    document["entityId"] = this.id
     document["json"] = Gson().toJson(this)
     document["class"] = this::class.java.name
     return document

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
@@ -49,7 +49,6 @@ class NitriteEntityTrashCollectorTest {
             properties = ArticleProperties(mutableMapOf("::property::" to entry))
     )
 
-    private lateinit var trashedId: String
 
     private val entryTrashCollectionName = "Test_entries_trash"
 
@@ -60,8 +59,6 @@ class NitriteEntityTrashCollectorTest {
     @Before
     fun setUp() {
         val trashedDoc = trashedEntry.toDocument()
-        trashedId = trashedDoc.get("entityId", String::class.java)
-
         coll.insert(trashedDoc)
     }
 
@@ -83,16 +80,16 @@ class NitriteEntityTrashCollectorTest {
 
     @Test
     fun `Restore entity from trash`() {
-        val restoredEntry = trashCollector.restore(trashedId, Entry::class.java)
+        val restoredEntry = trashCollector.restore(trashedEntry.id, Entry::class.java)
 
         assertThat(restoredEntry, Is(trashedEntry))
     }
 
     @Test
     fun `Restoring entity removes it from trash`() {
-        trashCollector.restore(trashedId, Entry::class.java)
+        trashCollector.restore(trashedEntry.id, Entry::class.java)
 
-        assertThat(coll.find("entityId" eq trashedId).firstOrNull(), Is(nullValue()))
+        assertThat(coll.find("entityId" eq trashedEntry.id).firstOrNull(), Is(nullValue()))
     }
 
     @Test(expected = EntityNotInTrashException::class)
@@ -102,7 +99,7 @@ class NitriteEntityTrashCollectorTest {
 
     @Test(expected = EntityCannotBeCastException::class)
     fun `Restoring entity and casting it to wrong type throws exception`() {
-        trashCollector.restore(trashedId, Article::class.java)
+        trashCollector.restore(trashedEntry.id, Article::class.java)
     }
 
     @Test

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflowTest.kt
@@ -2,6 +2,7 @@ package com.tsbonev.nharker.server.workflow
 
 import com.tsbonev.nharker.core.Article
 import com.tsbonev.nharker.core.Catalogue
+import com.tsbonev.nharker.core.Entity
 import com.tsbonev.nharker.core.EntityCannotBeCastException
 import com.tsbonev.nharker.core.EntityNotInTrashException
 import com.tsbonev.nharker.core.Entry
@@ -126,7 +127,7 @@ class TrashingWorkflowTest {
 
     @Suppress("UNCHECKED_CAST")
     @Test
-    fun `Clearin trash store returns cleared entities`() {
+    fun `Clearing trash store returns cleared entities`() {
         val entityList = listOf(entry, article, catalogue)
 
         context.expecting {
@@ -142,7 +143,7 @@ class TrashingWorkflowTest {
 
         assertThat(response.statusCode, Is(StatusCode.OK))
         assertThat(response.payload.isPresent, Is(true))
-        assertThat(response.payload.get() as List<Any>, Is(entityList))
+        assertThat(response.payload.get() as List<Entity>, Is(entityList))
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Wrote an interface for every Domain Entity that contains an id and creationDate, thus the trash collector can rely that everything it receives has an id field and can use that for saving.  Closes #130.