### PR TITLE
nharker-core: save trashed domain objects with own id

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleLinks.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleLinks.kt
@@ -1,27 +1,53 @@
 package com.tsbonev.nharker.core
 
 /**
+ * Provides the methods to modify a mutable map by
+ * keeping track of how many times a link has been mentioned.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-data class ArticleLinks(val links: MutableMap<String, Int>) {
+data class ArticleLinks(val links: MutableMap<String, Int> = mutableMapOf()) {
 
-    fun get(articleTitle: String): Int? {
-        return links[articleTitle]
+    /**
+     * Returns the amount of times an article has been mentioned.
+     *
+     * @param articleLinkTitle The link title of the article.
+     * @return A nullable integer.
+     */
+    fun get(articleLinkTitle: String): Int? {
+        return links[articleLinkTitle]
     }
 
-    fun contains(articleTitle: String): Boolean {
-        return links[articleTitle] != null
+    /**
+     * Checks whether an article is mentioned.
+     *
+     * @param articleLinkTitle The article to check.
+     * @return Whether or not it is mentioned.
+     */
+    fun contains(articleLinkTitle: String): Boolean {
+        return links[articleLinkTitle] != null
     }
 
-    fun addLink(articleTitle: String) {
-        links[articleTitle] = (links[articleTitle] ?: 0) + 1
+    /**
+     * Adds a link to the map, incrementing its mentioned counter.
+     *
+     * @param articleLinkTitle The link to add.
+     */
+    fun addLink(articleLinkTitle: String) {
+        links[articleLinkTitle] = (links[articleLinkTitle] ?: 0) + 1
     }
 
-    fun removeLink(articleTitle: String) {
-        if (contains(articleTitle)) {
-            val timesMentioned = links[articleTitle]!! - 1
-            if (timesMentioned <= 0) links.remove(articleTitle)
-            else links[articleTitle] = timesMentioned
+    /**
+     * Removes a link mention from the map, decrementing its mentioned counter
+     * and removing it completely if it reaches zero.
+     *
+     * @param articleLinkTitle The link to decrement.
+     */
+    fun removeLink(articleLinkTitle: String) {
+        if (contains(articleLinkTitle)) {
+            val timesMentioned = links[articleLinkTitle]!! - 1
+            if (timesMentioned <= 0) links.remove(articleLinkTitle)
+            else links[articleLinkTitle] = timesMentioned
         }
     }
 }

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleProperties.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleProperties.kt
@@ -1,17 +1,38 @@
 package com.tsbonev.nharker.core
 
 /**
+ * Provides the methods to handle a map of properties.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class ArticleProperties(private val map: MutableMap<String, Entry> = mutableMapOf()) {
+
+    /**
+     * Attaches a property to the map, replacing it if present already.
+     *
+     * @param propertyName The name of the property.
+     * @param property The entry describing the property.
+     */
     fun attachProperty(propertyName: String, property: Entry) {
         this.map[propertyName] = property
     }
 
+    /**
+     * Returns the raw map.
+     *
+     * @return A map of Property Names and Entries.
+     */
     fun getAll(): Map<String, Entry> {
         return this.map
     }
 
+    /**
+     * Detaches a property from the map, throwing an exception
+     * if it is not found.
+     *
+     * @param propertyName The name of the property to remove.
+     * @return The removed property Entry.
+     */
     fun detachProperty(propertyName: String): Entry {
         val entry = map[propertyName] ?: throw PropertyNotFoundException(propertyName)
         map.remove(propertyName)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entity.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
  * Defines what a Domain Entity must contain to
  * be considered a Domain Entity.
  *
- * @author Tsvetozar Bonev (tsvetozar.bonev@clouway.com)
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 interface Entity {
     val id: String

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/EntityConverters.kt
@@ -13,6 +13,8 @@ import org.dizitart.no2.Document
 /**
  * Converts an entity to a document with three fields:
  * a class, an id and a json body.
+ *
+ * @return The converted document.
  */
 fun Entity.toDocument(): Document {
     val document = Document()
@@ -25,6 +27,8 @@ fun Entity.toDocument(): Document {
 /**
  * Converts any document with a class and json field to
  * that class.
+ *
+ * @return The converted entity.
  */
 fun Document.toEntity(): Any {
     return Gson().fromJson(this["json"].toString(),

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/OrderedMap.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/OrderedMap.kt
@@ -1,9 +1,20 @@
 package com.tsbonev.nharker.core.helpers
 
 /**
+ * Helper extension functions that handle a map of format Map<Any, Int>.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 
+/**
+ * Switches the order of two elements in a map.
+ *
+ * @param first The first element to switch.
+ * @param second The second element to switch.
+ * @return A new map with the elements switched.
+ *
+ * If one of the elements is not in the map, throws exception.
+ */
 fun <T : Any> Map<T, Int>.switch(first: T, second: T): Map<T, Int> {
     val mutableMap = this.toMutableMap()
     val firstVal = mutableMap[first] ?: throw ElementNotInMapException(first)
@@ -15,12 +26,25 @@ fun <T : Any> Map<T, Int>.switch(first: T, second: T): Map<T, Int> {
     return mutableMap
 }
 
+/**
+ * Appends an element to an ordered map.
+ *
+ * @param value The element to append.
+ * @return A new map with the appended element.
+ */
 fun <T> Map<T, Int>.append(value: T): Map<T, Int> {
     val mutableMap = this.toMutableMap()
     mutableMap[value] = mutableMap.size
     return mutableMap
 }
 
+/**
+ * Subtracts an element from an ordered map and rearranges the rest
+ * of the elements.
+ *
+ * @param value The value to subtract.
+ * @return A new map with the value subtracted.
+ */
 fun <T : Any> Map<T, Int>.subtract(value: T): Map<T, Int> {
     val mutableMap = this.toMutableMap()
     val removedSpace = mutableMap[value] ?: throw ElementNotInMapException(value)
@@ -32,6 +56,19 @@ fun <T : Any> Map<T, Int>.subtract(value: T): Map<T, Int> {
     }
 
     return mutableMap
+}
+
+/**
+ * Sorts a map by its int values.
+ *
+ * @return A new map with sorted by value pairs.
+ */
+fun <T> Map<T, Int>.sortByValues(): Map<T, Int> {
+    return this.toList()
+            .sortedBy {
+                (_, order) -> order
+            }
+            .toMap()
 }
 
 class ElementNotInMapException(val element: Any) : Throwable()

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedMapHelpersTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedMapHelpersTest.kt
@@ -56,4 +56,23 @@ class OrderedMapHelpersTest {
     fun `Switching non-existent id throws exception`() {
         mutableMap.switch("::non-existent-id::", "::non-existent-id::")
     }
+
+    @Test
+    fun `Orders map by values`(){
+        holderMap = mapOf(
+                "Three" to 2,
+                "One" to 0,
+                "Two" to 1
+        )
+
+        holderMap = holderMap.sortByValues()
+
+        assertThat(holderMap, Is(
+                mapOf(
+                        "One" to 0,
+                        "Two" to 1,
+                        "Three" to 2
+                )
+        ))
+    }
 }


### PR DESCRIPTION
Added logic to restore an article's entries, properties and links when restoring from the trash.
Added verification logic to an entry's explicit links when restoring from the trash.
Covers first point of #129.

Added documentation for OrderedMap, ArticleLinks and ArticleProperties, closes #136.