### PR TITLE
nharker-core: restructure articles

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
@@ -1,5 +1,6 @@
 package com.tsbonev.nharker.adapter.nitrite
 
+import com.tsbonev.nharker.core.Article
 import com.tsbonev.nharker.core.Entries
 import com.tsbonev.nharker.core.Entry
 import com.tsbonev.nharker.core.EntryNotFoundException
@@ -34,6 +35,7 @@ class NitriteEntries(private val nitriteDb: Nitrite,
         val entry = Entry(
                 NitriteId.newId().toString(),
                 LocalDateTime.now(clock),
+                entryRequest.articleId,
                 entryRequest.content,
                 entryRequest.links
         )
@@ -77,6 +79,15 @@ class NitriteEntries(private val nitriteDb: Nitrite,
     override fun updateLinks(entryId: String, links: Map<String, String>): Entry {
         val entry = findByIdOrThrow(entryId)
         val updatedEntry = entry.copy(links = links)
+
+        coll.update(updatedEntry)
+        return updatedEntry
+    }
+
+    override fun changeArticle(entryId: String, article: Article): Entry {
+        val entry = findByIdOrThrow(entryId)
+        val updatedEntry = entry.copy(articleId = article.id)
+
 
         coll.update(updatedEntry)
         return updatedEntry

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Article.kt
@@ -1,5 +1,6 @@
 package com.tsbonev.nharker.core
 
+import com.tsbonev.nharker.core.helpers.OrderedRefMap
 import org.dizitart.no2.IndexType
 import org.dizitart.no2.objects.Id
 import org.dizitart.no2.objects.Index
@@ -10,7 +11,8 @@ import java.time.LocalDateTime
  * Articles are the main building block of
  * NHarker's organization scheme, they keep track
  * of entries and handle automatically linking
- * to each other based on each entry's content.
+ * to each other based on each entry's content, as
+ * well as keeping track of the catalogues they are a part of.
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
@@ -20,8 +22,9 @@ data class Article(@Id override val id: String,
                    val linkTitle: String,
                    val fullTitle: String,
                    override val creationDate: LocalDateTime,
+                   val catalogues: Set<String> = emptySet(),
                    val properties: ArticleProperties = ArticleProperties(),
-                   val entries: Map<String, Int> = emptyMap(),
+                   val entries: OrderedRefMap = emptyMap(),
                    val links: ArticleLinks = ArticleLinks(mutableMapOf())) : Entity
 
 /**
@@ -31,6 +34,7 @@ fun String.toLinkTitle(): String {
     return this.toLowerCase()
             .replace("\\s+".toRegex(), "-")
             .replace("\'", "")
+            .replace(":", "")
             .replace(",", "")
             .replace(".", "")
 }

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleRequest.kt
@@ -1,6 +1,10 @@
 package com.tsbonev.nharker.core
 
 /**
+ * A request object containing all of the necessary
+ * information for the creation of an Article object.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-data class ArticleRequest(val fullTitle: String)
+data class ArticleRequest(val fullTitle: String,
+                          val catalogues: List<String>)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -40,6 +40,37 @@ interface Articles {
     fun getById(articleId: String): Optional<Article>
 
     /**
+     * Retrieves a list of articles who have a given catalogue id
+     * in their catalogues list.
+     *
+     * @param catalogue The catalogue sought.
+     * @return A list of articles.
+     */
+    fun getByCatalogue(catalogue: Catalogue) : List<Article>
+
+    /**
+     * Adds a catalogue id to an article's catalogues list.
+     *
+     * @param articleId The id of the article.
+     * @param catalogue The catalogue to add.
+     *
+     * @return The updated article.
+     */
+    @Throws(ArticleNotFoundException::class)
+    fun addCatalogue(articleId: String, catalogue: Catalogue) : Article
+
+    /**
+     * Removes a catalogue's id from an article's catalogues list.
+     *
+     * @param articleId The id of the article.
+     * @param catalogue The catalogue to remove.
+     *
+     * @return The updated article.
+     */
+    @Throws(ArticleNotFoundException::class)
+    fun removeCatalogue(articleId: String, catalogue: Catalogue) : Article
+
+    /**
      * Appends an entry to an article.
      *
      * @param articleId The id of the article targeted.
@@ -97,7 +128,7 @@ interface Articles {
     fun detachProperty(articleId: String, propertyName: String): Article
 
     /**
-     * Returns an article with a given link title.
+     * Retrieves an article with a given link title.
      *
      * @param linkTitle The link title to search for.
      * @return An optional article.
@@ -113,7 +144,7 @@ interface Articles {
     fun searchByFullTitle(searchString: String): List<Article>
 
     /**
-     * Returns a list of all article titles that match a set of
+     * Retrieves a list of all article titles that match a set of
      * link titles.
      *
      * @param linkTitleList The links to match to.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogue.kt
@@ -1,5 +1,6 @@
 package com.tsbonev.nharker.core
 
+import com.tsbonev.nharker.core.helpers.OrderedRefMap
 import org.dizitart.no2.IndexType
 import org.dizitart.no2.objects.Id
 import org.dizitart.no2.objects.Index
@@ -8,9 +9,9 @@ import java.time.LocalDateTime
 
 /**
  * Catalogues are the entity that groups together
- * articles into coherent categories. Catalogues
- * can nest each other and order articles and
- * their nested subcatalogues.
+ * articles into coherent categories, as such
+ * Catalogues are only concerned with the underlying
+ * inheritance tree that they make up.
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
@@ -19,8 +20,7 @@ import java.time.LocalDateTime
 data class Catalogue(@Id override val id: String,
                      val title: String,
                      override val creationDate: LocalDateTime,
-                     val articles: Map<String, Int> = emptyMap(),
-                     val subCatalogues: Map<String, Int> = emptyMap(),
+                     val childrenIds: OrderedRefMap = emptyMap(),
                      val parentId: String? = null) : Entity
 
 class CatalogueNotFoundException(val catalogueId: String) : Throwable()
@@ -30,6 +30,3 @@ class CatalogueAlreadyAChildException(val parentCatalogueId: String, val childCa
 class CatalogueNotAChildException(val parentCatalogueId: String, val childCatalogueId: String) : Throwable()
 class SelfContainedCatalogueException(val catalogueId: String) : Throwable()
 class CatalogueCircularInheritanceException(val parentCatalogueId: String, val childCatalogueId: String) : Throwable()
-
-class ArticleAlreadyInCatalogueException(val catalogueId: String, val articleId: String) : Throwable()
-class ArticleNotInCatalogueException(val catalogueId: String, val articleId: String) : Throwable()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/CatalogueRequest.kt
@@ -1,6 +1,9 @@
 package com.tsbonev.nharker.core
 
 /**
+ * A request object containing all of the necessary
+ * information for creating a Catalogue object.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class CatalogueRequest(val title: String,

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
@@ -75,7 +75,7 @@ interface Catalogues {
             CatalogueAlreadyAChildException::class,
             SelfContainedCatalogueException::class,
             CatalogueCircularInheritanceException::class)
-    fun appendSubCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
+    fun appendChildCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
 
     /**
      * Removes a catalogue from the targeted catalogue's children list.
@@ -86,44 +86,10 @@ interface Catalogues {
      */
     @Throws(CatalogueNotFoundException::class,
             CatalogueNotAChildException::class)
-    fun removeSubCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
+    fun removeChildCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
 
     /**
-     * Appends an article from a catalogue.
-     *
-     * @param parentCatalogueId The id of the catalogue targeted.
-     * @param article The article to append.
-     * @return The updated catalogue.
-     */
-    @Throws(CatalogueNotFoundException::class,
-            ArticleAlreadyInCatalogueException::class)
-    fun appendArticle(parentCatalogueId: String, article: Article): Catalogue
-
-    /**
-     * Removes an article from a catalogue.
-     *
-     * @param parentCatalogueId The id of the catalogue targeted.
-     * @param article The  article to remove.
-     * @return The updated catalogue.
-     */
-    @Throws(CatalogueNotFoundException::class,
-            ArticleNotInCatalogueException::class)
-    fun removeArticle(parentCatalogueId: String, article: Article): Catalogue
-
-    /**
-     * Switches the order of two articles in a catalogue.
-     *
-     * @param catalogueId The id of the catalogue targeted.
-     * @param first The first article.
-     * @param second The second article.
-     * @return The updated catalogue.
-     */
-    @Throws(CatalogueNotFoundException::class,
-            ArticleNotInCatalogueException::class)
-    fun switchArticles(catalogueId: String, first: Article, second: Article): Catalogue
-
-    /**
-     * Switches the order of two subcatalogues in a catalogue.
+     * Switches the order of two children catalogues in a parent catalogue.
      *
      * @param parentCatalogueId The id of the catalogue targeted.
      * @param firstChild The first catalogue.
@@ -132,5 +98,5 @@ interface Catalogues {
      */
     @Throws(CatalogueNotFoundException::class,
             CatalogueNotAChildException::class)
-    fun switchSubCatalogues(parentCatalogueId: String, firstChild: Catalogue, secondChild: Catalogue): Catalogue
+    fun switchChildCatalogues(parentCatalogueId: String, firstChild: Catalogue, secondChild: Catalogue): Catalogue
 }

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entries.kt
@@ -52,7 +52,18 @@ interface Entries {
     fun updateLinks(entryId: String, links: Map<String, String>): Entry
 
     /**
-     * Returns an optional entry by id.
+     * Changes the parent article of an entry.
+     *
+     * @param entryId The id of the entry.
+     * @param article The new article that holds the entry.
+     *
+     * @return The updated entry.
+     */
+    @Throws(EntryNotFoundException::class)
+    fun changeArticle(entryId: String, article: Article): Entry
+
+    /**
+     * Retrieves an optional entry by id.
      *
      * @param entryId The id of the entry sought.
      * @return An optional entry.
@@ -60,7 +71,7 @@ interface Entries {
     fun getById(entryId: String): Optional<Entry>
 
     /**
-     * Returns a list of entries matching a text search.
+     * Retrieves a list of entries matching a text search.
      *
      * @param searchText The text to search by.
      * @return A list of matching entries.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Entry.kt
@@ -6,6 +6,9 @@ import org.dizitart.no2.objects.Index
 import org.dizitart.no2.objects.Indices
 import java.time.LocalDateTime
 
+typealias Phrase = String
+typealias Link = String
+
 /**
  * Entries are the main wrapper of information,
  * they may contain links that are explicit which
@@ -14,10 +17,12 @@ import java.time.LocalDateTime
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-@Indices(Index(value = "content", type = IndexType.Fulltext))
+@Indices(Index(value = "content", type = IndexType.Fulltext),
+        Index(value = "articleId", type = IndexType.NonUnique))
 data class Entry(@Id override val id: String,
                  override val creationDate: LocalDateTime,
+                 val articleId: String,
                  val content: String,
-                 val links: Map<String, String> = emptyMap()) : Entity
+                 val links: Map<Phrase, Link> = emptyMap()) : Entity
 
 class EntryNotFoundException(val entryId: String) : Throwable()

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryRequest.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryRequest.kt
@@ -1,7 +1,11 @@
 package com.tsbonev.nharker.core
 
 /**
+ * A request object containing all of the information necessary
+ * for the creation of an Entry object.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class EntryRequest(val content: String,
+                        val articleId: String,
                         val links: Map<String, String>)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/OrderedRefMap.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/helpers/OrderedRefMap.kt
@@ -7,6 +7,17 @@ package com.tsbonev.nharker.core.helpers
  */
 
 /**
+ * Aliases to better convey what the parts of an ordered ref map are.
+ */
+typealias Order = Int
+typealias Reference = String
+
+/**
+ * An alias used to identify an ordered reference map.
+ */
+typealias OrderedRefMap = Map<Reference, Order>
+
+/**
  * Switches the order of two elements in a map.
  *
  * @param first The first element to switch.
@@ -15,7 +26,7 @@ package com.tsbonev.nharker.core.helpers
  *
  * If one of the elements is not in the map, throws exception.
  */
-fun <T : Any> Map<T, Int>.switch(first: T, second: T): Map<T, Int> {
+fun <T : Any> Map<T, Order>.switch(first: T, second: T): Map<T, Order> {
     val mutableMap = this.toMutableMap()
     val firstVal = mutableMap[first] ?: throw ElementNotInMapException(first)
     val secondVal = mutableMap[second] ?: throw ElementNotInMapException(second)
@@ -32,7 +43,7 @@ fun <T : Any> Map<T, Int>.switch(first: T, second: T): Map<T, Int> {
  * @param value The element to append.
  * @return A new map with the appended element.
  */
-fun <T> Map<T, Int>.append(value: T): Map<T, Int> {
+fun <T> Map<T, Order>.append(value: T): Map<T, Order> {
     val mutableMap = this.toMutableMap()
     mutableMap[value] = mutableMap.size
     return mutableMap
@@ -45,7 +56,7 @@ fun <T> Map<T, Int>.append(value: T): Map<T, Int> {
  * @param value The value to subtract.
  * @return A new map with the value subtracted.
  */
-fun <T : Any> Map<T, Int>.subtract(value: T): Map<T, Int> {
+fun <T : Any> Map<T, Order>.subtract(value: T): Map<T, Order> {
     val mutableMap = this.toMutableMap()
     val removedSpace = mutableMap[value] ?: throw ElementNotInMapException(value)
 
@@ -63,7 +74,7 @@ fun <T : Any> Map<T, Int>.subtract(value: T): Map<T, Int> {
  *
  * @return A new map with sorted by value pairs.
  */
-fun <T> Map<T, Int>.sortByValues(): Map<T, Int> {
+fun <T> Map<T, Order>.sortByValues(): Map<T, Order> {
     return this.toList()
             .sortedBy {
                 (_, order) -> order

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProviderTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticleSynonymProviderTest.kt
@@ -29,13 +29,13 @@ class NitriteArticleSynonymProviderTest {
     )
 
     private val article = Article(
-            "::articleId::",
+            "::article-id::",
             "article-title",
             "Article title",
             LocalDateTime.now()
     )
 
-    private val synonymMap = mapOf("::presavedSynonym::" to "article-title")
+    private val synonymMap = mapOf("::presaved-synonym::" to "article-title")
 
     @Suppress("UNCHECKED_CAST")
     private val presavedMap: Map<String, String>
@@ -77,12 +77,12 @@ class NitriteArticleSynonymProviderTest {
 
     @Test(expected = SynonymAlreadyTakenException::class)
     fun `Adding existing synonym throws exception`() {
-        synonymMapProvider.addSynonym("::presavedSynonym::", article)
+        synonymMapProvider.addSynonym("::presaved-synonym::", article)
     }
 
     @Test
     fun `Remove synonym from map`() {
-        synonymMapProvider.removeSynonym("::presavedSynonym::")
+        synonymMapProvider.removeSynonym("::presaved-synonym::")
 
 
         assertThat(presavedMap, Is(emptyMap()))

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntityTrashCollectorTest.kt
@@ -30,23 +30,25 @@ class NitriteEntityTrashCollectorTest {
     private val date = LocalDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneOffset.UTC)
 
     private val entry = Entry(
-            "::entryId::",
+            "::entry-id::",
             date,
+            articleId = "::article-id::",
             content = "::content::"
     )
 
     private val trashedEntry = Entry(
-            "::trashedEntryId::",
+            "::trashed-entry-id::",
             date,
+            "::article-id::",
             content = "::content::"
     )
 
     private val article = Article(
-            "::articleId::",
-            "article-id",
-            "Article id",
+            "::article-id::",
+            "article-title",
+            "Article title",
             date,
-            properties = ArticleProperties(mutableMapOf("::property::" to entry))
+            properties = ArticleProperties(mutableMapOf("::property-name::" to entry))
     )
 
 

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitritePaginatorTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitritePaginatorTest.kt
@@ -23,16 +23,19 @@ class NitritePaginatorTest {
     private val firstEntry = Entry(
             "::first-entry-id::",
             LocalDateTime.ofEpochSecond(1, 1, ZoneOffset.UTC),
+            "::article-id::",
             "::content::"
     )
     private val secondEntry = Entry(
             "::second-entry-id::",
             LocalDateTime.ofEpochSecond(2, 2, ZoneOffset.UTC),
+            "::article-id::",
             "::content::"
     )
     private val thirdEntry = Entry(
             "::third-entry-id::",
             LocalDateTime.ofEpochSecond(3, 3, ZoneOffset.UTC),
+            "::article-id::",
             "::content::"
     )
 

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/SimpleEntryLinkerTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/SimpleEntryLinkerTest.kt
@@ -13,6 +13,7 @@ import org.hamcrest.CoreMatchers.`is` as Is
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
+@Suppress("SpellCheckingInspection")
 class SimpleEntryLinkerTest {
 
     @Rule
@@ -48,8 +49,9 @@ class SimpleEntryLinkerTest {
             "The College of Conciliators is home to conciliators."
 
     private val entry = Entry(
-            "::entryId::",
+            "::entry-id::",
             LocalDateTime.now(),
+            "::article-id::",
             content,
             explicitEntryLinks
     )
@@ -95,8 +97,9 @@ class SimpleEntryLinkerTest {
         }
 
         val entry = Entry(
-                "::entryId::",
+                "::entry-id::",
                 LocalDateTime.now(),
+                "::article-id::",
                 "There are no articles that have any of these words as a link title."
         )
 

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedRefMapTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/helpers/OrderedRefMapTest.kt
@@ -7,9 +7,9 @@ import org.hamcrest.CoreMatchers.`is` as Is
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-class OrderedMapHelpersTest {
+class OrderedRefMapTest {
 
-    private lateinit var holderMap: Map<String, Int>
+    private lateinit var holderMap: OrderedRefMap
     private val mutableMap = mutableMapOf<String, Int>()
 
     @Test

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/helpers/ExceptionLogger.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/helpers/ExceptionLogger.kt
@@ -1,8 +1,6 @@
 package com.tsbonev.nharker.server.helpers
 
-import com.tsbonev.nharker.core.ArticleAlreadyInCatalogueException
 import com.tsbonev.nharker.core.ArticleNotFoundException
-import com.tsbonev.nharker.core.ArticleNotInCatalogueException
 import com.tsbonev.nharker.core.ArticleTitleTakenException
 import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
 import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
@@ -72,16 +70,6 @@ class ExceptionLogger {
             is CatalogueNotFoundException -> {
                 logger.error("Could not find catalogue with id ${e.catalogueId}!")
                 CommandResponse(StatusCode.NotFound)
-            }
-
-            is ArticleNotInCatalogueException -> {
-                logger.error("The article with id ${e.articleId} is not in the catalogue with id ${e.catalogueId}!")
-                CommandResponse(StatusCode.BadRequest)
-            }
-
-            is ArticleAlreadyInCatalogueException -> {
-                logger.error("The article with id ${e.articleId} is already in the catalogue with id ${e.catalogueId}")
-                CommandResponse(StatusCode.BadRequest)
             }
 
             is CatalogueNotAChildException -> {

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflow.kt
@@ -318,7 +318,8 @@ class ArticleWorkflow(private val eventBus: EventBus,
                 this.id,
                 this.linkTitle,
                 this.fullTitle,
-                this.creationDate
+                this.creationDate,
+                this.catalogues
         )
     }
 

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflow.kt
@@ -1,8 +1,5 @@
 package com.tsbonev.nharker.server.workflow
 
-import com.tsbonev.nharker.core.Article
-import com.tsbonev.nharker.core.ArticleAlreadyInCatalogueException
-import com.tsbonev.nharker.core.ArticleNotInCatalogueException
 import com.tsbonev.nharker.core.Catalogue
 import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
 import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
@@ -140,7 +137,7 @@ class CatalogueWorkflow(private val eventBus: EventBus,
     }
 
     /**
-     * Appends a subcatalogue to a catalogue.
+     * Appends a child catalogue to a catalogue.
      * @code 200
      * @payload The updated catalogue.
      * @publishes CatalogueUpdatedEvent
@@ -158,9 +155,9 @@ class CatalogueWorkflow(private val eventBus: EventBus,
      * @code 404
      */
     @CommandHandler
-    fun appendSubCatalogue(command: AppendSubCatalogueCommand): CommandResponse {
+    fun appendChildCatalogue(command: AppendChildCatalogueCommand): CommandResponse {
         return try {
-            val updatedCatalogue = catalogues.appendSubCatalogue(command.parentCatalogueId, command.childCatalogue)
+            val updatedCatalogue = catalogues.appendChildCatalogue(command.parentCatalogueId, command.childCatalogue)
 
             eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
             CommandResponse(StatusCode.OK, updatedCatalogue)
@@ -176,21 +173,21 @@ class CatalogueWorkflow(private val eventBus: EventBus,
     }
 
     /**
-     * Switches the order of two subcatalogues.
+     * Switches the order of two child catalogues.
      * @code 200
      * @payload The updated catalogue.
      * @publishes CatalogueUpdatedEvent
      *
-     * If the catalogue does not contain both subcatalogues, logs the catalogue's id and the subcatalogues' ids.
+     * If the catalogue does not contain both child catalogues, logs the catalogue's id and the child catalogues' ids.
      * @code 400
      *
      * If the catalogue is not found by id, logs the id
      * @code 404
      */
     @CommandHandler
-    fun switchSubCatalogues(command: SwitchSubCataloguesCommand): CommandResponse {
+    fun switchChildCatalogues(command: SwitchChildCataloguesCommand): CommandResponse {
         return try {
-            val updatedCatalogue = catalogues.switchSubCatalogues(
+            val updatedCatalogue = catalogues.switchChildCatalogues(
                     command.catalogueId, command.first, command.second)
 
             eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
@@ -203,104 +200,25 @@ class CatalogueWorkflow(private val eventBus: EventBus,
     }
 
     /**
-     * Removes a subcatalogue from a parent catalogue.
+     * Removes a child catalogue from a parent catalogue.
      * @code 200
      * @payload The updated catalogue.
      * @publishes CatalogueUpdatedEvent
      *
-     * If the subcatalogue is not a child, logs the parent's and the child's ids.
+     * If the child catalogue is not a child, logs the parent's and the child's ids.
      * @code 400
      *
      * If the parent catalogue is not found by id, logs the id.
      * @code 404
      */
     @CommandHandler
-    fun removeSubCatalogue(command: RemoveSubCatalogueCommand): CommandResponse {
+    fun removeChildCatalogue(command: RemoveChildCatalogueCommand): CommandResponse {
         return try {
-            val updatedCatalogue = catalogues.removeSubCatalogue(command.parentCatalogueId, command.childCatalogue)
+            val updatedCatalogue = catalogues.removeChildCatalogue(command.parentCatalogueId, command.childCatalogue)
 
             eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
             CommandResponse(StatusCode.OK, updatedCatalogue)
         } catch (e: CatalogueNotAChildException) {
-            exceptionLogger.logException(e)
-        } catch (e: CatalogueNotFoundException) {
-            exceptionLogger.logException(e)
-        }
-    }
-
-    /**
-     * Appends a article to a catalogue.
-     * @code 200
-     * @payload The updated catalogue.
-     * @publishes CatalogueUpdatedEvent
-     *
-     * If the article is already a child, logs the article's and the catalogue's ids.
-     * @code 400
-     *
-     * If the parent catalogue is not found by id, logs the id.
-     * @code 404
-     */
-    @CommandHandler
-    fun appendArticle(command: AppendArticleToCatalogueCommand): CommandResponse {
-        return try {
-            val updatedCatalogue = catalogues.appendArticle(command.parentCatalogueId, command.article)
-
-            eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
-            CommandResponse(StatusCode.OK, updatedCatalogue)
-        } catch (e: ArticleAlreadyInCatalogueException) {
-            exceptionLogger.logException(e)
-        } catch (e: CatalogueNotFoundException) {
-            exceptionLogger.logException(e)
-        }
-    }
-
-    /**
-     * Switches the order of two articles in a catalogue.
-     * @code 200
-     * @payload The updated catalogue.
-     * @publishes CatalogueUpdatedEvent
-     *
-     * If the catalogue does not contain both articles, logs the catalogue's id and the articles' ids.
-     * @code 400
-     *
-     * If the catalogue is not found by id, logs the id
-     * @code 404
-     */
-    @CommandHandler
-    fun switchArticlesInCatalogue(command: SwitchArticlesInCatalogueCommand): CommandResponse {
-        return try {
-            val updatedCatalogue = catalogues.switchArticles(
-                    command.catalogueId, command.first, command.second)
-
-            eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
-            CommandResponse(StatusCode.OK, updatedCatalogue)
-        } catch (e: ArticleNotInCatalogueException) {
-            exceptionLogger.logException(e)
-        } catch (e: CatalogueNotFoundException) {
-            exceptionLogger.logException(e)
-        }
-    }
-
-    /**
-     * Removes an article from a catalogue.
-     * @code 200
-     * @payload The updated catalogue.
-     * @publishes CatalogueUpdatedEvent
-     *
-     * If the article is not contained in the catalogue, logs the article's and the catalogue's ids.
-     * @code 400
-     *
-     * If the parent catalogue is not found by id, logs the id.
-     * @code 404
-     */
-    @CommandHandler
-    fun removeArticle(command: RemoveArticleFromCatalogueCommand): CommandResponse {
-        return try {
-            val updatedCatalogue = catalogues.removeArticle(command.parentCatalogueId, command.article)
-
-            eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
-            CommandResponse(StatusCode.OK, updatedCatalogue)
-        } catch (e: ArticleNotInCatalogueException) {
             exceptionLogger.logException(e)
         } catch (e: CatalogueNotFoundException) {
             exceptionLogger.logException(e)
@@ -354,12 +272,9 @@ data class CatalogueDeletedEvent(val catalogue: Catalogue) : Event
 
 data class ChangeCatalogueTitleCommand(val catalogueId: String, val newTitle: String) : Command
 data class ChangeCatalogueParentCommand(val catalogueId: String, val newParent: Catalogue) : Command
-data class AppendSubCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
-data class RemoveSubCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
-data class AppendArticleToCatalogueCommand(val parentCatalogueId: String, val article: Article) : Command
-data class RemoveArticleFromCatalogueCommand(val parentCatalogueId: String, val article: Article) : Command
-data class SwitchArticlesInCatalogueCommand(val catalogueId: String, val first: Article, val second: Article) : Command
-data class SwitchSubCataloguesCommand(val catalogueId: String, val first: Catalogue, val second: Catalogue) : Command
+data class AppendChildCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
+data class RemoveChildCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
+data class SwitchChildCataloguesCommand(val catalogueId: String, val first: Catalogue, val second: Catalogue) : Command
 data class CatalogueUpdatedEvent(val catalogue: Catalogue) : Event
 
 //endregion

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
@@ -168,6 +168,7 @@ class EntryWorkflow(private val eventBus: EventBus,
 
         return Entry(this.id,
                 this.creationDate,
+                this.articleId,
                 this.content,
                 rebuiltEntryLinks)
     }

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
@@ -45,26 +45,29 @@ class ArticleWorkflowTest {
     private val articleWorkflow = ArticleWorkflow(eventBus, articles, exceptionLogger)
 
     private val articleRequest = ArticleRequest(
-            "Full title"
+            "Full title",
+            listOf("::catalogue-id::")
     )
 
     private val entry = Entry(
             "::entry-id::",
             LocalDateTime.now(),
+            "::id::",
             "::content::"
     )
 
     private val propertyEntry = Entry(
             "::property-id::",
             LocalDateTime.now(),
+            "::article-id::",
             "::content::"
     )
-
     private val article = Article(
-            "::id::",
-            "full-title",
-            "Full title",
+            "::article-id::",
+            "article-title",
+            "Article title",
             LocalDateTime.now(),
+            catalogues = setOf("::catalogue-id::"),
             entries = mapOf("::entry-id::" to 0),
             properties = ArticleProperties(mutableMapOf("::property::" to propertyEntry))
     )

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflowTest.kt
@@ -1,8 +1,6 @@
 package com.tsbonev.nharker.server.workflow
 
 import com.tsbonev.nharker.core.Article
-import com.tsbonev.nharker.core.ArticleAlreadyInCatalogueException
-import com.tsbonev.nharker.core.ArticleNotInCatalogueException
 import com.tsbonev.nharker.core.Catalogue
 import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
 import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
@@ -271,14 +269,14 @@ class CatalogueWorkflowTest {
     @Test
     fun `Append subcatalogue to catalogue`() {
         context.expecting {
-            oneOf(catalogues).appendSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
             will(returnValue(catalogue))
 
             oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
         }
 
-        val response = catalogueWorkflow.appendSubCatalogue(
-                AppendSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.appendChildCatalogue(
+                AppendChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.OK))
         assertThat(response.payload.isPresent, Is(true))
@@ -288,12 +286,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Appending catalogue to itself returns bad request`() {
         context.expecting {
-            oneOf(catalogues).appendSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
             will(throwException(SelfContainedCatalogueException(catalogue.id)))
         }
 
-        val response = catalogueWorkflow.appendSubCatalogue(
-                AppendSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.appendChildCatalogue(
+                AppendChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.BadRequest))
         assertThat(response.payload.isPresent, Is(false))
@@ -302,12 +300,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Appending catalogue to its child returns bad request`() {
         context.expecting {
-            oneOf(catalogues).appendSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
             will(throwException(CatalogueCircularInheritanceException(catalogue.id, catalogue.id)))
         }
 
-        val response = catalogueWorkflow.appendSubCatalogue(
-                AppendSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.appendChildCatalogue(
+                AppendChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.BadRequest))
         assertThat(response.payload.isPresent, Is(false))
@@ -316,12 +314,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Appending catalogue that is already a child returns bad request`() {
         context.expecting {
-            oneOf(catalogues).appendSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
             will(throwException(CatalogueAlreadyAChildException(catalogue.id, catalogue.id)))
         }
 
-        val response = catalogueWorkflow.appendSubCatalogue(
-                AppendSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.appendChildCatalogue(
+                AppendChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.BadRequest))
         assertThat(response.payload.isPresent, Is(false))
@@ -330,12 +328,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Appending subcatalogue to a non-existent catalogue returns not found`() {
         context.expecting {
-            oneOf(catalogues).appendSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
             will(throwException(CatalogueNotFoundException(catalogue.id)))
         }
 
-        val response = catalogueWorkflow.appendSubCatalogue(
-                AppendSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.appendChildCatalogue(
+                AppendChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.NotFound))
         assertThat(response.payload.isPresent, Is(false))
@@ -344,14 +342,14 @@ class CatalogueWorkflowTest {
     @Test
     fun `Switch subcatalogue order in catalogue`() {
         context.expecting {
-            oneOf(catalogues).switchSubCatalogues(catalogue.id, catalogue, catalogue)
+            oneOf(catalogues).switchChildCatalogues(catalogue.id, catalogue, catalogue)
             will(returnValue(catalogue))
 
             oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
         }
 
-        val response = catalogueWorkflow.switchSubCatalogues(
-                SwitchSubCataloguesCommand(catalogue.id, catalogue, catalogue))
+        val response = catalogueWorkflow.switchChildCatalogues(
+                SwitchChildCataloguesCommand(catalogue.id, catalogue, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.OK))
         assertThat(response.payload.isPresent, Is(true))
@@ -361,12 +359,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Switching subcatalogue orders in a catalogue that does not contain both returns bad request`() {
         context.expecting {
-            oneOf(catalogues).switchSubCatalogues(catalogue.id, catalogue, catalogue)
+            oneOf(catalogues).switchChildCatalogues(catalogue.id, catalogue, catalogue)
             will(throwException(CatalogueNotAChildException(catalogue.id, catalogue.id)))
         }
 
-        val response = catalogueWorkflow.switchSubCatalogues(
-                SwitchSubCataloguesCommand(catalogue.id, catalogue, catalogue))
+        val response = catalogueWorkflow.switchChildCatalogues(
+                SwitchChildCataloguesCommand(catalogue.id, catalogue, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.BadRequest))
         assertThat(response.payload.isPresent, Is(false))
@@ -375,12 +373,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Switching subcatalogue orders in a non-existing catalogue returns not found`() {
         context.expecting {
-            oneOf(catalogues).switchSubCatalogues(catalogue.id, catalogue, catalogue)
+            oneOf(catalogues).switchChildCatalogues(catalogue.id, catalogue, catalogue)
             will(throwException(CatalogueNotFoundException(catalogue.id)))
         }
 
-        val response = catalogueWorkflow.switchSubCatalogues(
-                SwitchSubCataloguesCommand(catalogue.id, catalogue, catalogue))
+        val response = catalogueWorkflow.switchChildCatalogues(
+                SwitchChildCataloguesCommand(catalogue.id, catalogue, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.NotFound))
         assertThat(response.payload.isPresent, Is(false))
@@ -389,14 +387,14 @@ class CatalogueWorkflowTest {
     @Test
     fun `Remove subcatalogue from catalogue`() {
         context.expecting {
-            oneOf(catalogues).removeSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
             will(returnValue(catalogue))
 
             oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
         }
 
-        val response = catalogueWorkflow.removeSubCatalogue(
-                RemoveSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.removeChildCatalogue(
+                RemoveChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.OK))
         assertThat(response.payload.isPresent, Is(true))
@@ -406,12 +404,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Removing subcatalogue from non-parent catalogue returns bad request`() {
         context.expecting {
-            oneOf(catalogues).removeSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
             will(throwException(CatalogueNotAChildException(catalogue.id, catalogue.id)))
         }
 
-        val response = catalogueWorkflow.removeSubCatalogue(
-                RemoveSubCatalogueCommand(catalogue.id, catalogue))
+        val response = catalogueWorkflow.removeChildCatalogue(
+                RemoveChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.BadRequest))
         assertThat(response.payload.isPresent, Is(false))
@@ -420,147 +418,12 @@ class CatalogueWorkflowTest {
     @Test
     fun `Removing subcatalogue from a non-existent catalogue returns not found`() {
         context.expecting {
-            oneOf(catalogues).removeSubCatalogue(catalogue.id, catalogue)
+            oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
             will(throwException(CatalogueNotFoundException(catalogue.id)))
         }
 
-        val response = catalogueWorkflow.removeSubCatalogue(
-                RemoveSubCatalogueCommand(catalogue.id, catalogue))
-
-        assertThat(response.statusCode, Is(StatusCode.NotFound))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Append article to catalogue`() {
-        context.expecting {
-            oneOf(catalogues).appendArticle(catalogue.id, article)
-            will(returnValue(catalogue))
-
-            oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
-        }
-
-        val response = catalogueWorkflow.appendArticle(
-                AppendArticleToCatalogueCommand(catalogue.id, article))
-
-        assertThat(response.statusCode, Is(StatusCode.OK))
-        assertThat(response.payload.isPresent, Is(true))
-        assertThat(response.payload.get() as Catalogue, Is(catalogue))
-    }
-
-    @Test
-    fun `Appending article that is already contained in the catalogue returns bad request`() {
-        context.expecting {
-            oneOf(catalogues).appendArticle(catalogue.id, article)
-            will(throwException(ArticleAlreadyInCatalogueException(catalogue.id, article.id)))
-        }
-
-        val response = catalogueWorkflow.appendArticle(
-                AppendArticleToCatalogueCommand(catalogue.id, article))
-
-        assertThat(response.statusCode, Is(StatusCode.BadRequest))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Appending article to a non-existent catalogue returns not found`() {
-        context.expecting {
-            oneOf(catalogues).appendArticle(catalogue.id, article)
-            will(throwException(CatalogueNotFoundException(catalogue.id)))
-        }
-
-        val response = catalogueWorkflow.appendArticle(
-                AppendArticleToCatalogueCommand(catalogue.id, article))
-
-        assertThat(response.statusCode, Is(StatusCode.NotFound))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Switch article order in catalogue`() {
-        context.expecting {
-            oneOf(catalogues).switchArticles(catalogue.id, article, article)
-            will(returnValue(catalogue))
-
-            oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
-        }
-
-        val response = catalogueWorkflow.switchArticlesInCatalogue(
-                SwitchArticlesInCatalogueCommand(catalogue.id, article, article))
-
-        assertThat(response.statusCode, Is(StatusCode.OK))
-        assertThat(response.payload.isPresent, Is(true))
-        assertThat(response.payload.get() as Catalogue, Is(catalogue))
-    }
-
-    @Test
-    fun `Switching article orders in a catalogue that does not contain both returns bad request`() {
-        context.expecting {
-            oneOf(catalogues).switchArticles(catalogue.id, article, article)
-            will(throwException(ArticleNotInCatalogueException(catalogue.id, article.id)))
-        }
-
-        val response = catalogueWorkflow.switchArticlesInCatalogue(
-                SwitchArticlesInCatalogueCommand(catalogue.id, article, article))
-
-        assertThat(response.statusCode, Is(StatusCode.BadRequest))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Switching article orders in a non-existing catalogue returns not found`() {
-        context.expecting {
-            oneOf(catalogues).switchArticles(catalogue.id, article, article)
-            will(throwException(CatalogueNotFoundException(catalogue.id)))
-        }
-
-        val response = catalogueWorkflow.switchArticlesInCatalogue(
-                SwitchArticlesInCatalogueCommand(catalogue.id, article, article))
-
-        assertThat(response.statusCode, Is(StatusCode.NotFound))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Remove article from catalogue`() {
-        context.expecting {
-            oneOf(catalogues).removeArticle(catalogue.id, article)
-            will(returnValue(catalogue))
-
-            oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
-        }
-
-        val response = catalogueWorkflow.removeArticle(
-                RemoveArticleFromCatalogueCommand(catalogue.id, article))
-
-        assertThat(response.statusCode, Is(StatusCode.OK))
-        assertThat(response.payload.isPresent, Is(true))
-        assertThat(response.payload.get() as Catalogue, Is(catalogue))
-    }
-
-    @Test
-    fun `Removing article that is not contained in catalogue returns bad request`() {
-        context.expecting {
-            oneOf(catalogues).removeArticle(catalogue.id, article)
-            will(throwException(ArticleNotInCatalogueException(catalogue.id, article.id)))
-        }
-
-        val response = catalogueWorkflow.removeArticle(
-                RemoveArticleFromCatalogueCommand(catalogue.id, article))
-
-        assertThat(response.statusCode, Is(StatusCode.BadRequest))
-        assertThat(response.payload.isPresent, Is(false))
-    }
-
-    @Test
-    fun `Removing article from a non-existent catalogue returns not found`() {
-        context.expecting {
-            oneOf(catalogues).removeArticle(catalogue.id, article)
-            will(throwException(CatalogueNotFoundException(catalogue.id)))
-        }
-
-        val response = catalogueWorkflow.removeArticle(
-                RemoveArticleFromCatalogueCommand(catalogue.id, article))
+        val response = catalogueWorkflow.removeChildCatalogue(
+                RemoveChildCatalogueCommand(catalogue.id, catalogue))
 
         assertThat(response.statusCode, Is(StatusCode.NotFound))
         assertThat(response.payload.isPresent, Is(false))

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
@@ -39,10 +39,12 @@ class EntryWorkflowTest {
     private val entryWorkflow = EntryWorkflow(eventBus, entries, exceptionLogger)
 
     private val entryRequest = EntryRequest("::content::",
+            "::article-id::",
             emptyMap())
 
     private val entry = Entry("::entryId::",
             LocalDateTime.now(),
+            "::article-id::",
             "::content::",
             emptyMap())
 
@@ -252,28 +254,29 @@ class EntryWorkflowTest {
 
     @Test
     fun `Restoring an entry verifies its links`(){
-        val article = Article(
+        val restoredArticle = Article(
                 "::article-id::",
                 "full-title",
                 "Full title",
                 LocalDateTime.now()
         )
 
-        val entry = Entry(
+        val restoredEntry = Entry(
                 "::entry-id::",
                 LocalDateTime.now(),
+                "::article-id::",
                 "::content::",
                 mapOf("::phrase::" to "::link::")
         )
 
         context.expecting {
             oneOf(eventBus).send(GetArticleByLinkTitleCommand("::link::"))
-            will(returnValue(CommandResponse(StatusCode.OK, article)))
+            will(returnValue(CommandResponse(StatusCode.OK, restoredArticle)))
 
-            oneOf(entries).save(entry)
+            oneOf(entries).save(restoredEntry)
         }
 
-        entryWorkflow.onEntryRestored(EntityRestoredEvent(entry, Entry::class.java))
+        entryWorkflow.onEntryRestored(EntityRestoredEvent(restoredEntry, Entry::class.java))
     }
 
     @Test
@@ -281,6 +284,7 @@ class EntryWorkflowTest {
         val entry = Entry(
                 "::entry-id::",
                 LocalDateTime.now(),
+                "::article-id::",
                 "::content::",
                 mapOf("::phrase::" to "::link::")
         )

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflowTest.kt
@@ -41,6 +41,7 @@ class TrashingWorkflowTest {
     private val entry = Entry(
             "::entry-id::",
             LocalDateTime.now(),
+            "::article-id::",
             "::content::"
     )
 


### PR DESCRIPTION
Part of #139.
Retouched some documentation and test code style. Closes #143.
Refactored Articles to contain a reference to their catalogues. Closes #142.
Refactored Catalogues to only care about their inheritance trees and not about Articles.
Refactored Entries to keep a reference to their parent article. Closes #138.