### PR TITLE
nharker-core/server: clean up after ordered ref map implementation

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -50,7 +50,7 @@ class NitriteArticles(private val nitriteDb: Nitrite,
                 LocalDateTime.now(clock)
         )
 
-        if (coll.find(Article::linkTitle eq article.linkTitle).firstOrNull() != null)
+        if (coll.find(Article::linkTitle eq article.linkTitle).any())
             throw ArticleTitleTakenException(articleRequest.fullTitle)
 
         coll.insert(article)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCatalogues.kt
@@ -115,9 +115,9 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
                 .raw()
                 .keys
                 .forEach {
-            val subCatalogue = coll.find(Catalogue::id eq it).first()
-            coll.update(Catalogue::id eq it, subCatalogue.copy(parentId = catalogue.parentId))
-        }
+                    val subCatalogue = coll.find(Catalogue::id eq it).first()
+                    coll.update(Catalogue::id eq it, subCatalogue.copy(parentId = catalogue.parentId))
+                }
 
         coll.remove(Catalogue::id eq catalogueId)
         return catalogue
@@ -172,7 +172,7 @@ class NitriteCatalogues(private val nitriteDb: Nitrite,
             coll.update(catalogue)
             catalogue
         } catch (ex: ElementNotInMapException) {
-            throw CatalogueNotAChildException(parentCatalogueId, ex.reference as String)
+            throw CatalogueNotAChildException(parentCatalogueId, ex.reference)
         }
     }
 

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleProperties.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/ArticleProperties.kt
@@ -25,7 +25,7 @@ data class ArticleProperties(private val map: MutableMap<PropertyName, EntryRefe
      *
      * @return A map of Property Names and Entry ids.
      */
-    fun getAll(): Map<PropertyName, EntryReference> {
+    fun raw(): Map<PropertyName, EntryReference> {
         return this.map
     }
 

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -46,7 +46,7 @@ interface Articles {
      * @param catalogue The catalogue sought.
      * @return A list of articles.
      */
-    fun getByCatalogue(catalogue: Catalogue) : List<Article>
+    fun getByCatalogue(catalogue: Catalogue): List<Article>
 
     /**
      * Adds a catalogue id to an article's catalogues list.
@@ -57,7 +57,7 @@ interface Articles {
      * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class)
-    fun addCatalogue(articleId: String, catalogue: Catalogue) : Article
+    fun addCatalogue(articleId: String, catalogue: Catalogue): Article
 
     /**
      * Removes a catalogue's id from an article's catalogues list.
@@ -68,7 +68,7 @@ interface Articles {
      * @return The updated article.
      */
     @Throws(ArticleNotFoundException::class)
-    fun removeCatalogue(articleId: String, catalogue: Catalogue) : Article
+    fun removeCatalogue(articleId: String, catalogue: Catalogue): Article
 
     /**
      * Appends an entry to an article.

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/OrderedReferenceMap.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/OrderedReferenceMap.kt
@@ -53,6 +53,8 @@ data class OrderedReferenceMap(private val map: LinkedHashMap<String, Int> = lin
 
     /**
      * Returns the raw map.
+     *
+     * @return The ordered map.
      */
     fun raw(): Map<String, Int> {
         return map
@@ -64,17 +66,17 @@ data class OrderedReferenceMap(private val map: LinkedHashMap<String, Int> = lin
      * @param reference The reference to check for.
      * @return Whether the reference is in the map or not.
      */
-    fun contains(reference: String) : Boolean {
+    fun contains(reference: String): Boolean {
         return map.containsKey(reference)
     }
 
     /**
      * Sorts a map by its int values.
      */
-    private fun sortByValues(){
+    private fun sortByValues() {
         map.toList()
-                .sortedBy {
-                    (_, order) -> order
+                .sortedBy { (_, order) ->
+                    order
                 }
                 .toMap(map)
     }

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteCataloguesTest.kt
@@ -62,8 +62,8 @@ class NitriteCataloguesTest {
             "::catalogue-title::",
             date,
             OrderedReferenceMap(
-            linkedMapOf(firstPresavedSubcatalogue.id to 0,
-                    secondPresavedSubcatalogue.id to 1))
+                    linkedMapOf(firstPresavedSubcatalogue.id to 0,
+                            secondPresavedSubcatalogue.id to 1))
     )
 
     private val presavedCatalogue: Catalogue

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
@@ -126,7 +126,7 @@ class NitriteEntriesTest {
     }
 
     @Test
-    fun `Change entry article`(){
+    fun `Change entry article`() {
         val updatedEntry = entries.changeArticle(entry.id, article.copy("::new-article-id::"))
 
         assertThat(presavedEntry, Is(entry.copy(articleId = "::new-article-id::")))
@@ -134,7 +134,7 @@ class NitriteEntriesTest {
     }
 
     @Test(expected = EntryNotFoundException::class)
-    fun `Changing the article of a non-existent entry throws exception`(){
+    fun `Changing the article of a non-existent entry throws exception`() {
         entries.changeArticle("::non-existent-entry::", article)
     }
 

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/OrderedReferenceMapTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/core/OrderedReferenceMapTest.kt
@@ -19,10 +19,15 @@ class OrderedReferenceMapTest {
         assertThat(map.contains("One"), Is(true))
         assertThat(map.contains("Two"), Is(true))
         assertThat(map.contains("Three"), Is(false))
+
+        assertThat(map.raw(), Is(mapOf(
+                "One" to 0,
+                "Two" to 1
+        )))
     }
 
     @Test
-    fun `Subtracting from map reorders`() {
+    fun `Subtracting from map keeps order`() {
         map.append("One")
         map.append("Two")
         map.append("Three")
@@ -31,6 +36,11 @@ class OrderedReferenceMapTest {
 
         assertThat(map.raw()["One"]!!, Is(0))
         assertThat(map.raw()["Three"]!!, Is(1))
+
+        assertThat(map.raw(), Is(mapOf(
+                "One" to 0,
+                "Three" to 1
+        )))
     }
 
     @Test(expected = ElementNotInMapException::class)
@@ -39,7 +49,7 @@ class OrderedReferenceMapTest {
     }
 
     @Test
-    fun `Switching list ids reorders`() {
+    fun `Switching references reorders the list`() {
         map.append("One")
         map.append("Two")
         map.append("Three")
@@ -49,6 +59,12 @@ class OrderedReferenceMapTest {
         assertThat(map.raw()["One"]!!, Is(2))
         assertThat(map.raw()["Three"]!!, Is(0))
         assertThat(map.raw()["Two"]!!, Is(1))
+
+        assertThat(map.raw(), Is(mapOf(
+                "Three" to 0,
+                "Two" to 1,
+                "One" to 2
+        )))
     }
 
     @Test(expected = ElementNotInMapException::class)

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
@@ -156,12 +156,12 @@ class EntryWorkflow(private val eventBus: EventBus,
      *
      * @return The Entry with verified explicit links.
      */
-    private fun Entry.verifyLinks() : Entry {
-        val rebuiltEntryLinks= mutableMapOf<String, String>()
+    private fun Entry.verifyLinks(): Entry {
+        val rebuiltEntryLinks = mutableMapOf<String, String>()
 
         this.links.forEach { phrase, link ->
             val response = eventBus.send(GetArticleByLinkTitleCommand(link))
-            if(response.statusCode.isSuccess()){
+            if (response.statusCode.isSuccess()) {
                 rebuiltEntryLinks[phrase] = link
             }
         }
@@ -175,12 +175,15 @@ class EntryWorkflow(private val eventBus: EventBus,
 }
 
 //region Queries
+
 data class GetEntryByIdCommand(val entryId: String) : Command
 
 data class SearchEntriesByContentCommand(val searchText: String) : Command
+
 //endregion
 
 //region Commands
+
 data class CreateEntryCommand(val entryRequest: EntryRequest) : Command
 
 data class EntryCreatedEvent(val entry: Entry) : Event
@@ -191,4 +194,5 @@ data class EntryDeletedEvent(val entry: Entry) : Event
 data class UpdateEntryContentCommand(val entryId: String, val content: String) : Command
 data class UpdateEntryLinksCommand(val entryId: String, val entryLinks: Map<String, String>) : Command
 data class EntryUpdatedEvent(val entry: Entry) : Event
+
 //endregion

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/PaginationWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/PaginationWorkflow.kt
@@ -66,6 +66,7 @@ class PaginationWorkflow(private val paginators: Map<Class<*>, Paginator<*>>,
     }
 
     //endregion
+
     /**
      * Returns the correct paginator for a given class.
      */
@@ -75,6 +76,7 @@ class PaginationWorkflow(private val paginators: Map<Class<*>, Paginator<*>>,
 }
 
 //region Queries
+
 data class GetPaginatedDomainObjectsCommand(val order: SortBy,
                                             val page: Int,
                                             val pageSize: Int,
@@ -82,6 +84,7 @@ data class GetPaginatedDomainObjectsCommand(val order: SortBy,
 
 data class GetAllDomainObjectsCommand(val order: SortBy,
                                       val objectType: Class<*>) : Command
+
 //endregion
 
 /**

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/TrashingWorkflow.kt
@@ -115,14 +115,18 @@ class TrashingWorkflow(private val eventBus: EventBus,
 }
 
 //region Queries
+
 data class ViewTrashedEntitiesCommand(val entityClass: Class<*>) : Command
+
 //endregion
 
 //region Commands
+
 data class RestoreTrashedEntityCommand(val entityId: String, val entityClass: Class<*>) : Command
 
 data class EntityRestoredEvent(val entity: Any, val entityClass: Class<*>) : Event
 
 class ClearTrashStoreCommand : Command
 data class TrashStoreClearedEvent(val deletedEntities: List<Any>) : Event
+
 //endregion

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
@@ -456,21 +456,14 @@ class ArticleWorkflowTest {
             oneOf(eventBus).send(GetEntryByIdCommand(propertyEntry.id))
             will(returnValue(CommandResponse(StatusCode.OK, propertyEntry)))
 
-            //Restoring the links
-            oneOf(eventBus).send(GetEntryByIdCommand(entry.id))
-            will(returnValue(CommandResponse(StatusCode.OK, entry)))
-
-            oneOf(eventBus).send(GetEntryByIdCommand(propertyEntry.id))
-            will(returnValue(CommandResponse(StatusCode.OK, propertyEntry)))
-
-            oneOf(articles).save(article.copy(links = ArticleLinks(mutableMapOf("::property::" to 1))))
+            oneOf(articles).save(article)
         }
 
         articleWorkflow.onArticleRestored(EntityRestoredEvent(article, Article::class.java))
     }
 
     @Test
-    fun `Restoring article restores its deleted references and relinks itself`(){
+    fun `Restoring article restores its deleted references and relinks itself`() {
         val entryWithLinks = entry.copy(
                 links = mapOf("::phrase::" to "::link::")
         )
@@ -494,16 +487,9 @@ class ArticleWorkflowTest {
             oneOf(eventBus).send(RestoreTrashedEntityCommand(propertyEntry.id, Entry::class.java))
             will(returnValue(CommandResponse(StatusCode.OK, propertyWithLinks)))
 
-            //Restoring the links
-            oneOf(eventBus).send(GetEntryByIdCommand(entry.id))
-            will(returnValue(CommandResponse(StatusCode.OK, entryWithLinks)))
-
-            oneOf(eventBus).send(GetEntryByIdCommand(propertyEntry.id))
-            will(returnValue(CommandResponse(StatusCode.OK, propertyEntry)))
-
             oneOf(articles).save(article.copy(
                     properties = ArticleProperties(mutableMapOf("::property::" to propertyWithLinks.id)),
-                    links = ArticleLinks(mutableMapOf("::property::" to 1, "::link::" to 1))
+                    links = ArticleLinks(mutableMapOf("::link::" to 2))
             ))
         }
 
@@ -511,7 +497,7 @@ class ArticleWorkflowTest {
     }
 
     @Test
-    fun `Restoring article ignores missing references`(){
+    fun `Restoring article ignores missing references`() {
         context.expecting {
             //Restoring the entries
             oneOf(eventBus).send(GetEntryByIdCommand(entry.id))

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
@@ -253,7 +253,7 @@ class EntryWorkflowTest {
     }
 
     @Test
-    fun `Restoring an entry verifies its links`(){
+    fun `Restoring an entry verifies its links`() {
         val restoredArticle = Article(
                 "::article-id::",
                 "full-title",
@@ -280,7 +280,7 @@ class EntryWorkflowTest {
     }
 
     @Test
-    fun `Restoring entry skips unverified explicit links`(){
+    fun `Restoring entry skips unverified explicit links`() {
         val entry = Entry(
                 "::entry-id::",
                 LocalDateTime.now(),


### PR DESCRIPTION
Cleaned up some of the mess left by the initial implementation of the OrderedReferenceMap. Closes #145, closes #147.