### PR TITLE
entry-linker: remove saving from entry linking

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntryLinker.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntryLinker.kt
@@ -29,14 +29,12 @@ class NitriteEntryLinker(
 	}
 
 	override fun linkEntryToArticles(entry: Entry): Entry {
-		val linkedEntry = entry
+		return entry
 			.clearExplicitLinksFromContent()
 			.runFullTextLinking()
 			.clearImplicitLinksFromContent()
 			.runSynonymLinking()
 			.restoreOriginalContentFrom(entry)
-
-		return entries.save(linkedEntry)
 	}
 
 	/**

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryLinker.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/EntryLinker.kt
@@ -3,6 +3,8 @@ package com.tsbonev.nharker.core
 /**
  * Provides the methods necessary to automatically link
  * articles by looking up their entries' content.
+ * Note: The Entry Linker does not hold the responsibility
+ * of saving the affected objects into persistence.
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntryLinkerTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntryLinkerTest.kt
@@ -10,6 +10,7 @@ import org.jmock.AbstractExpectations.returnValue
 import org.jmock.Expectations
 import org.jmock.Mockery
 import org.jmock.integration.junit4.JUnitRuleMockery
+import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import java.time.LocalDateTime
@@ -55,8 +56,12 @@ class NitriteEntryLinkerTest {
 
 			oneOf(synonyms).getSynonymMap()
 			will(returnValue(mapOf("some other title" to "::article-id::")))
+		}
 
-			oneOf(entries).save(
+		val linkedEntry = linker.linkEntryToArticles(entry)
+
+		assertThat(
+			linkedEntry, Is(
 				entry.copy(
 					implicitLinks = mapOf(
 						"Article title" to article.id,
@@ -64,9 +69,7 @@ class NitriteEntryLinkerTest {
 					)
 				)
 			)
-		}
-
-		linker.linkEntryToArticles(entry)
+		)
 	}
 
 	@Test
@@ -80,18 +83,22 @@ class NitriteEntryLinkerTest {
 
 			oneOf(synonyms).getSynonymMap()
 			will(returnValue(mapOf("some other title" to "::article-id::")))
+		}
 
-			oneOf(entries).save(
-				entry.copy(
-					implicitLinks = mapOf(
-						"Article title" to article.id,
-						"some other title" to article.id
+		val linkedEntries = linker.refreshLinksOfArticle(article)
+
+		assertThat(
+			linkedEntries, Is(
+				listOf(
+					entry.copy(
+						implicitLinks = mapOf(
+							"Article title" to article.id,
+							"some other title" to article.id
+						)
 					)
 				)
 			)
-		}
-
-		linker.refreshLinksOfArticle(article)
+		)
 	}
 
 	private fun Mockery.expecting(block: Expectations.() -> Unit) {

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
@@ -12,7 +12,7 @@ import com.tsbonev.nharker.cqrs.StatusCode
 import com.tsbonev.nharker.cqrs.Workflow
 
 /**
- * Provides the commands to affect the links between entries and articles
+ * Provides the commands to affect the links between entries and articles.
  *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */


### PR DESCRIPTION
Removed the saving from the responsibilities of EntryLinker which will make future usage of the higher up workflows cleaner.
Closes #172.