### PR TITLE
nharker-server: retouch article restoration

### DIFF
--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
@@ -8,6 +8,7 @@ import com.tsbonev.nharker.cqrs.CommandHandler
 import com.tsbonev.nharker.cqrs.CommandResponse
 import com.tsbonev.nharker.cqrs.Event
 import com.tsbonev.nharker.cqrs.EventBus
+import com.tsbonev.nharker.cqrs.EventHandler
 import com.tsbonev.nharker.cqrs.StatusCode
 import com.tsbonev.nharker.cqrs.Workflow
 
@@ -52,7 +53,19 @@ class EntryLinkingWorkflow(
 	//endregion
 
 	//region Event Handlers
-
+	/**
+	 * Refreshes an entry's implicit links when restored.
+	 * @publishes EntryLinkedEvent
+	 */
+	@EventHandler
+	fun onEntryRestored(event: EntityRestoredEvent){
+		when(event.entity){
+			is Entry -> {
+				val refreshedEntry = linker.linkEntryToArticles(event.entity)
+				eventBus.publish(EntryLinkedEvent(refreshedEntry))
+			}
+		}
+	}
 	//endregion
 }
 //region Commands

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflow.kt
@@ -145,17 +145,13 @@ class EntryWorkflow(
 
 	//region Event Handlers
 	/**
-	 * Saves a restored entry and verifies its explicit links for existence.
+	 * Saves entries that have been linked after restoration.
 	 */
 	@EventHandler
-	fun onEntryRestored(event: EntityRestoredEvent) {
-		if (event.entityClass == Entry::class.java && event.entity is Entry) {
-			val restoredEntry = event.entity
+	fun onEntryLinked(event: EntryLinkedEvent) {
+		val verifiedEntry = event.entry.verifyLinks()
 
-			val verifiedEntry = restoredEntry.verifyLinks()
-
-			entries.save(verifiedEntry)
-		}
+		entries.save(verifiedEntry)
 	}
 	//endregion
 

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
@@ -551,6 +551,15 @@ class ArticleWorkflowTest {
 		articleWorkflow.onArticleRestored(EntityRestoredEvent(article, String::class.java))
 	}
 
+	@Test
+	fun `Relinks article's entries when refreshed`(){
+		context.expecting {
+			oneOf(eventBus).send(LinkEntryContentToArticlesCommand(entry))
+		}
+
+	    articleWorkflow.onArticleRefreshed(ArticleLinksRefreshedEvent(article, listOf(entry)))
+	}
+
 	private fun Mockery.expecting(block: Expectations.() -> Unit) {
 		checking(Expectations().apply(block))
 	}

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkerWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkerWorkflowTest.kt
@@ -84,6 +84,33 @@ class EntryLinkerWorkflowTest {
 		assertThat(response.payload.get() as List<Entry>, Is(listOf(entry)))
 	}
 
+	@Test
+	fun `Refreshes links of restored entries`(){
+		context.expecting {
+			oneOf(linker).linkEntryToArticles(entry)
+			will(returnValue(entry))
+
+			oneOf(eventBus).publish(EntryLinkedEvent(entry))
+		}
+
+		linkingWorkflow.onEntryRestored(
+			EntityRestoredEvent(entry, Entry::class.java)
+		)
+	}
+
+	@Test
+	fun `Ignores non-entry restoration events`(){
+		context.expecting {
+			never(linker).linkEntryToArticles(entry)
+
+			never(eventBus).publish(EntryLinkedEvent(entry))
+		}
+
+		linkingWorkflow.onEntryRestored(
+			EntityRestoredEvent(article, Article::class.java)
+		)
+	}
+
 	private fun Mockery.expecting(block: Expectations.() -> Unit){
 	        checking(Expectations().apply(block))
 	}

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryWorkflowTest.kt
@@ -251,16 +251,16 @@ class EntryWorkflowTest {
 	}
 
 	@Test
-	fun `Saves entry when completely restored`() {
+	fun `Saves entry when when linked after restoration`() {
 		context.expecting {
 			oneOf(entries).save(entry)
 		}
 
-		entryWorkflow.onEntryRestored(EntityRestoredEvent(entry, Entry::class.java))
+		entryWorkflow.onEntryLinked(EntryLinkedEvent(entry))
 	}
 
 	@Test
-	fun `Restoring entry verifies its links`() {
+	fun `Restoring linked entry verifies its links`() {
 		val restoredArticle = Article(
 			"::article-id::",
 			"Article title",
@@ -282,11 +282,11 @@ class EntryWorkflowTest {
 			oneOf(entries).save(restoredEntry)
 		}
 
-		entryWorkflow.onEntryRestored(EntityRestoredEvent(restoredEntry, Entry::class.java))
+		entryWorkflow.onEntryLinked(EntryLinkedEvent(restoredEntry))
 	}
 
 	@Test
-	fun `Restoring entry skips unverified explicit links`() {
+	fun `Restoring linked entry skips unverified explicit links`() {
 		val entry = Entry(
 			"::entry-id::",
 			LocalDateTime.now(),
@@ -306,16 +306,7 @@ class EntryWorkflowTest {
 			)
 		}
 
-		entryWorkflow.onEntryRestored(EntityRestoredEvent(entry, Entry::class.java))
-	}
-
-	@Test
-	fun `Ignores foreign restored entities`() {
-		context.expecting {
-			never(entries).save(entry)
-		}
-
-		entryWorkflow.onEntryRestored(EntityRestoredEvent(entry, String::class.java))
+		entryWorkflow.onEntryLinked(EntryLinkedEvent(entry))
 	}
 
 	private fun Mockery.expecting(block: Expectations.() -> Unit) {


### PR DESCRIPTION
Retouches article restoration by delegating the events as follow:

1. There should only be an endpoint to restore an Article.
2. This will spawn a RestoreTrashedEntity command for that Article, handled by the TrashingWorkflow.
2.1. This will publish an EntityRestoredEvent with that Article.
3. The ArticleWorfklow captures this EntityRestoredEvent when its an Article
and goes through the referenced Entries, spawning RestoreTrashedEntity commands for each.
3.1. The LinkingWorkflow will capture EntityRestoredEvents for Entries and refresh their links.
3.1.1. LinkingWorkflow will publish an EntityLinkedEvent.
3.2. The EntryWorkflow will capture EntityLinkedEvent and verify the explicit links, then it will save the Entry.
3.3. While all of this is going on, the Article will be saved with its gathered references.

Finishes the last point of- and closes #158.