### PR TITLE
articles: fix property detaching

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -176,13 +176,13 @@ class NitriteArticles(
 		return article
 	}
 
-	override fun detachProperty(articleId: String, propertyName: String): Article {
+	override fun detachProperty(articleId: String, propertyName: String): Pair<Article, String> {
 		val article = findByIdOrThrow(articleId)
 
-		article.properties.detachProperty(propertyName)
+		val removedPropertyId = article.properties.detachProperty(propertyName)
 
 		repo.update(article)
-		return article
+		return Pair(article, removedPropertyId)
 	}
 
 	override fun searchByFullTitle(searchString: String): List<Article> {

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Articles.kt
@@ -187,7 +187,7 @@ interface Articles {
 	 *
 	 * @param articleId The id of the targeted article.
 	 * @param propertyName The name of the property.
-	 * @return The updated article.
+	 * @return The updated article and the removed property id in a pair.
 	 *
 	 * @exception ArticleNotFoundException thrown when the article is not found.
 	 * @exception PropertyNotFoundException thrown when there is no property of the given name.
@@ -196,7 +196,7 @@ interface Articles {
 		ArticleNotFoundException::class,
 		PropertyNotFoundException::class
 	)
-	fun detachProperty(articleId: String, propertyName: String): Article
+	fun detachProperty(articleId: String, propertyName: String): Pair<Article, String>
 
 	/**
 	 * Returns a list of all articles that match a give title.

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticlesTest.kt
@@ -340,7 +340,7 @@ class NitriteArticlesTest {
 
 	@Test
 	fun `Attaches property to article`() {
-		val updatedArticle = articles.attachProperty(article.id, "::propertyName::", entry)
+		val updatedArticle = articles.attachProperty(article.id, "::property-name::", entry)
 
 		assertThat(
 			presavedArticle,
@@ -350,14 +350,15 @@ class NitriteArticlesTest {
 
 	@Test(expected = ArticleNotFoundException::class)
 	fun `Attaching property to non-existing article throws exception`() {
-		articles.attachProperty("::non-existing-article::", "::propertyName::", entry)
+		articles.attachProperty("::non-existing-article::", "::property-name::", entry)
 	}
 
 	@Test
 	fun `Detaches property from article`() {
-		val updatedArticle = articles.detachProperty(article.id, "::property-name::")
+		val articleEntryIdPair = articles.detachProperty(article.id, "::property-name::")
 
-		assertThat(presavedArticle, Is(updatedArticle))
+		assertThat(presavedArticle, Is(articleEntryIdPair.first))
+		assertThat(articleEntryIdPair.second, Is("::article-property-id::"))
 	}
 
 	@Test(expected = PropertyNotFoundException::class)

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
@@ -373,7 +373,9 @@ class ArticleWorkflowTest {
 	fun `Detaches property from article`() {
 		context.expecting {
 			oneOf(articles).detachProperty(article.id, propertyName)
-			will(returnValue(article))
+			will(returnValue(Pair(article, propertyEntry.id)))
+
+			oneOf(eventBus).send(DeleteEntryCommand(propertyEntry.id))
 
 			oneOf(eventBus).publish(ArticleUpdatedEvent(article))
 		}
@@ -387,7 +389,7 @@ class ArticleWorkflowTest {
 
 		assertThat(response.statusCode, Is(StatusCode.OK))
 		assertThat(response.payload.isPresent, Is(true))
-		assertThat(response.payload.get() as Article, Is(article))
+		assertThat(response.payload.get() as Pair<Article, String>, Is(Pair(article, propertyEntry.id)))
 	}
 
 	@Test


### PR DESCRIPTION
Detaching a property now returns the updated article and the id of the dereferenced property, making it possible to spawn a DeleteEntryCommand from the workflow. This completes the last point of- and closes #159.
This also fixes #175.