### PR TITLE
catalogues: fix old parent keeping reference

### DIFF
--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteArticles.kt
@@ -2,6 +2,7 @@ package com.tsbonev.nharker.adapter.nitrite
 
 import com.tsbonev.nharker.core.Article
 import com.tsbonev.nharker.core.ArticleNotFoundException
+import com.tsbonev.nharker.core.ArticlePaginationException
 import com.tsbonev.nharker.core.ArticleRequest
 import com.tsbonev.nharker.core.ArticleTitleTakenException
 import com.tsbonev.nharker.core.Articles
@@ -10,7 +11,6 @@ import com.tsbonev.nharker.core.ElementNotInMapException
 import com.tsbonev.nharker.core.Entry
 import com.tsbonev.nharker.core.EntryAlreadyInArticleException
 import com.tsbonev.nharker.core.EntryNotInArticleException
-import com.tsbonev.nharker.core.ArticlePaginationException
 import com.tsbonev.nharker.core.SortBy
 import org.dizitart.kno2.filters.elemMatch
 import org.dizitart.kno2.filters.eq
@@ -45,7 +45,8 @@ class NitriteArticles(
 
 		if (repo.find(Article::title text article.title)
 				.filter { it.title == article.title }
-				.any())
+				.any()
+		)
 			throw ArticleTitleTakenException(articleRequest.fullTitle)
 
 		repo.insert(article)

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntries.kt
@@ -5,7 +5,6 @@ import com.tsbonev.nharker.core.Entries
 import com.tsbonev.nharker.core.Entry
 import com.tsbonev.nharker.core.EntryNotFoundException
 import com.tsbonev.nharker.core.EntryRequest
-import com.tsbonev.nharker.core.SortBy
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.filters.text
 import org.dizitart.no2.Nitrite

--- a/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
+++ b/nharker-core/src/main/kotlin/com/tsbonev/nharker/core/Catalogues.kt
@@ -89,41 +89,15 @@ interface Catalogues {
 	fun changeParentCatalogue(childCatalogueId: String, parentCatalogue: Catalogue): Catalogue
 
 	/**
-	 * Appends a catalogue to the targeted catalogue's children list.
+	 * Orphans a catalogue by setting its parentId to null.
 	 *
-	 * @param parentCatalogueId The id of the targeted parent catalogue.
-	 * @param childCatalogue The child catalogue to append.
+	 * @param catalogueId The catalogue to orphan.
 	 * @return The updated parent catalogue.
 	 *
-	 * @exception CatalogueNotFoundException thrown when the parent catalogue is not found.
-	 * @exception CatalogueAlreadyAChildException thrown when the child catalogue is already a child.
-	 * @exception SelfContainedCatalogueException thrown when the parent catalogue would become its own parent.
-	 * @exception CatalogueCircularInheritanceException thrown when the child is
-	 * the parent of the requested parent.
+	 * @exception CatalogueNotFoundException thrown when the catalogue is not found.
 	 */
-	@Throws(
-		CatalogueNotFoundException::class,
-		CatalogueAlreadyAChildException::class,
-		SelfContainedCatalogueException::class,
-		CatalogueCircularInheritanceException::class
-	)
-	fun appendChildCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
-
-	/**
-	 * Removes a catalogue from the targeted catalogue's children list.
-	 *
-	 * @param parentCatalogueId The id of the parent catalogue.
-	 * @param childCatalogue The child catalogue to remove.
-	 * @return The updated parent catalogue.
-	 *
-	 * @exception CatalogueNotFoundException thrown when the parent catalogue is not found.
-	 * @exception CatalogueNotAChildException thrown when the catalogue is not a child.
-	 */
-	@Throws(
-		CatalogueNotFoundException::class,
-		CatalogueNotAChildException::class
-	)
-	fun removeChildCatalogue(parentCatalogueId: String, childCatalogue: Catalogue): Catalogue
+	@Throws(CatalogueNotFoundException::class)
+	fun orphanCatalogue(catalogueId: String): Catalogue
 
 	/**
 	 * Switches the order of two children catalogues in a parent catalogue.

--- a/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
+++ b/nharker-core/src/test/kotlin/com/tsbonev/nharker/adapter/nitrite/NitriteEntriesTest.kt
@@ -4,7 +4,6 @@ import com.tsbonev.nharker.core.Article
 import com.tsbonev.nharker.core.Entry
 import com.tsbonev.nharker.core.EntryNotFoundException
 import com.tsbonev.nharker.core.EntryRequest
-import com.tsbonev.nharker.core.SortBy
 import com.tsbonev.nharker.core.helpers.StubClock
 import org.dizitart.kno2.filters.eq
 import org.dizitart.kno2.nitrite

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/helpers/ExceptionLogger.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/helpers/ExceptionLogger.kt
@@ -1,6 +1,7 @@
 package com.tsbonev.nharker.server.helpers
 
 import com.tsbonev.nharker.core.ArticleNotFoundException
+import com.tsbonev.nharker.core.ArticlePaginationException
 import com.tsbonev.nharker.core.ArticleTitleTakenException
 import com.tsbonev.nharker.core.CatalogueAlreadyAChildException
 import com.tsbonev.nharker.core.CatalogueCircularInheritanceException
@@ -12,7 +13,6 @@ import com.tsbonev.nharker.core.EntityNotInTrashException
 import com.tsbonev.nharker.core.EntryAlreadyInArticleException
 import com.tsbonev.nharker.core.EntryNotFoundException
 import com.tsbonev.nharker.core.EntryNotInArticleException
-import com.tsbonev.nharker.core.ArticlePaginationException
 import com.tsbonev.nharker.core.PropertyNotFoundException
 import com.tsbonev.nharker.core.SelfContainedCatalogueException
 import com.tsbonev.nharker.core.SynonymAlreadyTakenException

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflow.kt
@@ -155,46 +155,6 @@ class CatalogueWorkflow(
 	}
 
 	/**
-	 * Appends a child catalogue to a catalogue.
-	 * @code 200
-	 * @payload The updated catalogue.
-	 * @publishes CatalogueUpdatedEvent
-	 *
-	 * If the parent catalogue is not found by id, logs the id.
-	 * @code 404
-	 * @exception CatalogueNotFoundException
-	 *
-	 * If the parent catalogue is also the child catalogue, logs the catalogue id.
-	 * @code 400
-	 * @exception CatalogueAlreadyAChildException
-	 *
-	 * If the child catalogue is already a child, logs the parent's and the child's ids.
-	 * @code 400
-	 * @exception SelfContainedCatalogueException
-	 *
-	 * If the parent catalogue is a child of the requested parent catalogue, logs the parent's and the child's ids.
-	 * @code 400
-	 * @exception CatalogueCircularInheritanceException
-	 */
-	@CommandHandler
-	fun appendChildCatalogue(command: AppendChildCatalogueCommand): CommandResponse {
-		return try {
-			val updatedCatalogue = catalogues.appendChildCatalogue(command.parentCatalogueId, command.childCatalogue)
-
-			eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
-			CommandResponse(StatusCode.OK, updatedCatalogue)
-		} catch (e: CatalogueNotFoundException) {
-			exceptionLogger.logException(e)
-		} catch (e: CatalogueAlreadyAChildException) {
-			exceptionLogger.logException(e)
-		} catch (e: SelfContainedCatalogueException) {
-			exceptionLogger.logException(e)
-		} catch (e: CatalogueCircularInheritanceException) {
-			exceptionLogger.logException(e)
-		}
-	}
-
-	/**
 	 * Switches the order of two child catalogues.
 	 * @code 200
 	 * @payload The updated catalogue.
@@ -225,29 +185,23 @@ class CatalogueWorkflow(
 	}
 
 	/**
-	 * Removes a child catalogue from a parent catalogue.
+	 * Orphans a catalogue.
 	 * @code 200
-	 * @payload The updated catalogue.
+	 * @payload The orphaned catalogue.
 	 * @publishes CatalogueUpdatedEvent
 	 *
-	 * If the parent catalogue is not found by id, logs the id.
+	 * If the catalogue is not found by id, logs the id.
 	 * @code 404
 	 * @exception CatalogueNotFoundException
-	 *
-	 * If the child catalogue is not a child, logs the parent's and the child's ids.
-	 * @code 400
-	 * @exception CatalogueNotAChildException
 	 */
 	@CommandHandler
-	fun removeChildCatalogue(command: RemoveChildCatalogueCommand): CommandResponse {
+	fun orphanCatalogue(command: OrphanCatalogueCommand): CommandResponse {
 		return try {
-			val updatedCatalogue = catalogues.removeChildCatalogue(command.parentCatalogueId, command.childCatalogue)
+			val updatedCatalogue = catalogues.orphanCatalogue(command.parentCatalogueId)
 
 			eventBus.publish(CatalogueUpdatedEvent(updatedCatalogue))
 			CommandResponse(StatusCode.OK, updatedCatalogue)
 		} catch (e: CatalogueNotFoundException) {
-			exceptionLogger.logException(e)
-		} catch (e: CatalogueNotAChildException) {
 			exceptionLogger.logException(e)
 		}
 	}
@@ -297,8 +251,7 @@ data class CatalogueDeletedEvent(val catalogue: Catalogue) : Event
 
 data class ChangeCatalogueTitleCommand(val catalogueId: String, val newTitle: String) : Command
 data class ChangeCatalogueParentCommand(val catalogueId: String, val newParent: Catalogue) : Command
-data class AppendChildCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
-data class RemoveChildCatalogueCommand(val parentCatalogueId: String, val childCatalogue: Catalogue) : Command
+data class OrphanCatalogueCommand(val parentCatalogueId: String) : Command
 data class SwitchChildCataloguesCommand(val catalogueId: String, val first: Catalogue, val second: Catalogue) : Command
 data class CatalogueUpdatedEvent(val catalogue: Catalogue) : Event
 //endregion

--- a/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
+++ b/nharker-server/src/main/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkingWorkflow.kt
@@ -30,7 +30,7 @@ class EntryLinkingWorkflow(
 	 * @publishes EntryLinkedEvent
 	 */
 	@CommandHandler
-	fun linkEntry(command: LinkEntryContentToArticlesCommand): CommandResponse{
+	fun linkEntry(command: LinkEntryContentToArticlesCommand): CommandResponse {
 		val linkedEntry = linker.linkEntryToArticles(command.entry)
 
 		eventBus.publish(EntryLinkedEvent(linkedEntry))
@@ -44,7 +44,7 @@ class EntryLinkingWorkflow(
 	 * @publishes ArticleLinksRefreshedEvent
 	 */
 	@CommandHandler
-	fun refreshArticleLinks(command: RefreshArticleEntryLinksCommand): CommandResponse{
+	fun refreshArticleLinks(command: RefreshArticleEntryLinksCommand): CommandResponse {
 		val refreshedEntries = linker.refreshLinksOfArticle(command.article)
 
 		eventBus.publish(ArticleLinksRefreshedEvent(command.article, refreshedEntries))
@@ -58,8 +58,8 @@ class EntryLinkingWorkflow(
 	 * @publishes EntryLinkedEvent
 	 */
 	@EventHandler
-	fun onEntryRestored(event: EntityRestoredEvent){
-		when(event.entity){
+	fun onEntryRestored(event: EntityRestoredEvent) {
+		when (event.entity) {
 			is Entry -> {
 				val refreshedEntry = linker.linkEntryToArticles(event.entity)
 				eventBus.publish(EntryLinkedEvent(refreshedEntry))
@@ -68,10 +68,12 @@ class EntryLinkingWorkflow(
 	}
 	//endregion
 }
-//region Commands
-data class RefreshArticleEntryLinksCommand(val article: Article): Command
-data class ArticleLinksRefreshedEvent(val article: Article, val entries: List<Entry>): Event
 
-data class LinkEntryContentToArticlesCommand(val entry: Entry): Command
-data class EntryLinkedEvent(val entry: Entry): Event
+//region Commands
+data class RefreshArticleEntryLinksCommand(val article: Article) : Command
+
+data class ArticleLinksRefreshedEvent(val article: Article, val entries: List<Entry>) : Event
+
+data class LinkEntryContentToArticlesCommand(val entry: Entry) : Command
+data class EntryLinkedEvent(val entry: Entry) : Event
 //endregion

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/ArticleWorkflowTest.kt
@@ -181,7 +181,7 @@ class ArticleWorkflowTest {
 	}
 
 	@Test
-	fun `Retrieves all articles`(){
+	fun `Retrieves all articles`() {
 		val sortOrder = SortBy.ASCENDING
 
 		context.expecting {
@@ -198,7 +198,7 @@ class ArticleWorkflowTest {
 	}
 
 	@Test
-	fun `Retrieves paginated articles`(){
+	fun `Retrieves paginated articles`() {
 		val sortOrder = SortBy.ASCENDING
 
 		context.expecting {
@@ -215,7 +215,7 @@ class ArticleWorkflowTest {
 	}
 
 	@Test
-	fun `Paginating with illegal page count and size returns bad request`(){
+	fun `Paginating with illegal page count and size returns bad request`() {
 		val sortOrder = SortBy.ASCENDING
 
 		context.expecting {
@@ -554,12 +554,12 @@ class ArticleWorkflowTest {
 	}
 
 	@Test
-	fun `Relinks article's entries when refreshed`(){
+	fun `Relinks article's entries when refreshed`() {
 		context.expecting {
 			oneOf(eventBus).send(LinkEntryContentToArticlesCommand(entry))
 		}
 
-	    articleWorkflow.onArticleRefreshed(ArticleLinksRefreshedEvent(article, listOf(entry)))
+		articleWorkflow.onArticleRefreshed(ArticleLinksRefreshedEvent(article, listOf(entry)))
 	}
 
 	private fun Mockery.expecting(block: Expectations.() -> Unit) {

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/CatalogueWorkflowTest.kt
@@ -282,84 +282,6 @@ class CatalogueWorkflowTest {
 	}
 
 	@Test
-	fun `Appends child catalogue to catalogue`() {
-		context.expecting {
-			oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
-			will(returnValue(catalogue))
-
-			oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
-		}
-
-		val response = catalogueWorkflow.appendChildCatalogue(
-			AppendChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.OK))
-		assertThat(response.payload.isPresent, Is(true))
-		assertThat(response.payload.get() as Catalogue, Is(catalogue))
-	}
-
-	@Test
-	fun `Appending catalogue to itself returns bad request`() {
-		context.expecting {
-			oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
-			will(throwException(SelfContainedCatalogueException(catalogue.id)))
-		}
-
-		val response = catalogueWorkflow.appendChildCatalogue(
-			AppendChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.BadRequest))
-		assertThat(response.payload.isPresent, Is(false))
-	}
-
-	@Test
-	fun `Appending catalogue to its child returns bad request`() {
-		context.expecting {
-			oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
-			will(throwException(CatalogueCircularInheritanceException(catalogue.id, catalogue.id)))
-		}
-
-		val response = catalogueWorkflow.appendChildCatalogue(
-			AppendChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.BadRequest))
-		assertThat(response.payload.isPresent, Is(false))
-	}
-
-	@Test
-	fun `Appending catalogue that is already a child returns bad request`() {
-		context.expecting {
-			oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
-			will(throwException(CatalogueAlreadyAChildException(catalogue.id, catalogue.id)))
-		}
-
-		val response = catalogueWorkflow.appendChildCatalogue(
-			AppendChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.BadRequest))
-		assertThat(response.payload.isPresent, Is(false))
-	}
-
-	@Test
-	fun `Appending child catalogue to a non-existing catalogue returns not found`() {
-		context.expecting {
-			oneOf(catalogues).appendChildCatalogue(catalogue.id, catalogue)
-			will(throwException(CatalogueNotFoundException(catalogue.id)))
-		}
-
-		val response = catalogueWorkflow.appendChildCatalogue(
-			AppendChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.NotFound))
-		assertThat(response.payload.isPresent, Is(false))
-	}
-
-	@Test
 	fun `Switches child catalogue order in catalogue`() {
 		context.expecting {
 			oneOf(catalogues).switchChildCatalogues(catalogue.id, catalogue, catalogue)
@@ -410,14 +332,14 @@ class CatalogueWorkflowTest {
 	@Test
 	fun `Removes child catalogue from catalogue`() {
 		context.expecting {
-			oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
+			oneOf(catalogues).orphanCatalogue(catalogue.id)
 			will(returnValue(catalogue))
 
 			oneOf(eventBus).publish(CatalogueUpdatedEvent(catalogue))
 		}
 
-		val response = catalogueWorkflow.removeChildCatalogue(
-			RemoveChildCatalogueCommand(catalogue.id, catalogue)
+		val response = catalogueWorkflow.orphanCatalogue(
+			OrphanCatalogueCommand(catalogue.id)
 		)
 
 		assertThat(response.statusCode, Is(StatusCode.OK))
@@ -426,29 +348,14 @@ class CatalogueWorkflowTest {
 	}
 
 	@Test
-	fun `Removing child catalogue from non-parent catalogue returns bad request`() {
-		context.expecting {
-			oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
-			will(throwException(CatalogueNotAChildException(catalogue.id, catalogue.id)))
-		}
-
-		val response = catalogueWorkflow.removeChildCatalogue(
-			RemoveChildCatalogueCommand(catalogue.id, catalogue)
-		)
-
-		assertThat(response.statusCode, Is(StatusCode.BadRequest))
-		assertThat(response.payload.isPresent, Is(false))
-	}
-
-	@Test
 	fun `Removing child catalogue from a non-existing catalogue returns not found`() {
 		context.expecting {
-			oneOf(catalogues).removeChildCatalogue(catalogue.id, catalogue)
+			oneOf(catalogues).orphanCatalogue(catalogue.id)
 			will(throwException(CatalogueNotFoundException(catalogue.id)))
 		}
 
-		val response = catalogueWorkflow.removeChildCatalogue(
-			RemoveChildCatalogueCommand(catalogue.id, catalogue)
+		val response = catalogueWorkflow.orphanCatalogue(
+			OrphanCatalogueCommand(catalogue.id)
 		)
 
 		assertThat(response.statusCode, Is(StatusCode.NotFound))

--- a/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkerWorkflowTest.kt
+++ b/nharker-server/src/test/kotlin/com/tsbonev/nharker/server/workflow/EntryLinkerWorkflowTest.kt
@@ -12,12 +12,12 @@ import org.jmock.AbstractExpectations.returnValue
 import org.jmock.Expectations
 import org.jmock.Mockery
 import org.jmock.integration.junit4.JUnitRuleMockery
+import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import org.hamcrest.CoreMatchers.`is` as Is
-import org.junit.Assert.assertThat
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
@@ -49,7 +49,7 @@ class EntryLinkerWorkflowTest {
 	private val linkingWorkflow = EntryLinkingWorkflow(eventBus, linker)
 
 	@Test
-	fun `Links entry to articles`(){
+	fun `Links entry to articles`() {
 		context.expecting {
 			oneOf(linker).linkEntryToArticles(entry)
 			will(returnValue(entry))
@@ -67,7 +67,7 @@ class EntryLinkerWorkflowTest {
 	}
 
 	@Test
-	fun `Refreshes articles entry links`(){
+	fun `Refreshes articles entry links`() {
 		context.expecting {
 			oneOf(linker).refreshLinksOfArticle(article)
 			will(returnValue(listOf(entry)))
@@ -85,7 +85,7 @@ class EntryLinkerWorkflowTest {
 	}
 
 	@Test
-	fun `Refreshes links of restored entries`(){
+	fun `Refreshes links of restored entries`() {
 		context.expecting {
 			oneOf(linker).linkEntryToArticles(entry)
 			will(returnValue(entry))
@@ -99,7 +99,7 @@ class EntryLinkerWorkflowTest {
 	}
 
 	@Test
-	fun `Ignores non-entry restoration events`(){
+	fun `Ignores non-entry restoration events`() {
 		context.expecting {
 			never(linker).linkEntryToArticles(entry)
 
@@ -111,7 +111,7 @@ class EntryLinkerWorkflowTest {
 		)
 	}
 
-	private fun Mockery.expecting(block: Expectations.() -> Unit){
-	        checking(Expectations().apply(block))
+	private fun Mockery.expecting(block: Expectations.() -> Unit) {
+		checking(Expectations().apply(block))
 	}
 }


### PR DESCRIPTION
Catalogues now can orphan a catalogue or change its parent, both of which now update the old parent's state. Fixes #178, fixes #177.